### PR TITLE
Add rate limit budget display to daemon status

### DIFF
--- a/src/forges/github.rs
+++ b/src/forges/github.rs
@@ -1089,12 +1089,14 @@ impl Forge for GitHubClient {
         }
         #[derive(Deserialize)]
         struct CoreLimit {
+            limit: u32,
             remaining: u32,
             reset: i64,
         }
 
         let result: RateLimitResponse = response.json().await?;
         Ok(Some(RateLimitInfo {
+            limit: result.resources.core.limit,
             remaining: result.resources.core.remaining,
             reset_at: result.resources.core.reset,
         }))

--- a/src/forges/mod.rs
+++ b/src/forges/mod.rs
@@ -347,8 +347,19 @@ pub struct CreateGoalRequest {
 /// Rate limit status from a forge
 #[derive(Debug, Clone)]
 pub struct RateLimitInfo {
+    /// Total requests allowed per hour
+    pub limit: u32,
+    /// Requests remaining this hour
     pub remaining: u32,
-    pub reset_at: i64, // Unix timestamp
+    /// Unix timestamp when the limit resets
+    pub reset_at: i64,
+}
+
+impl RateLimitInfo {
+    /// Calculate how many requests have been used this hour
+    pub fn used(&self) -> u32 {
+        self.limit.saturating_sub(self.remaining)
+    }
 }
 
 


### PR DESCRIPTION
Display per-forge rate limit budget usage in `isq daemon status`:
- Shows total budget (req/hr) and used this hour for each forge
- Tracks rate limits independently per forge (GitHub: 5000, Linear: 1500)
- Updates rate limit info after each successful sync

Changes:
- Extended RateLimitInfo struct with `limit` field
- Updated GitHub/Linear get_rate_limit to return full budget info
- Added rate_limit and remaining columns to rate_limit_state table
- Added update_rate_limit_budget() function to track API usage
- Updated daemon sync to save rate limit info after success
- Updated daemon status to display rate limit budget per forge
- Added unit tests for rate limit budget tracking