### PR TITLE
Add compact date to issue list, fix worktree detection

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -8,7 +8,7 @@
 
 use std::io::IsTerminal;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Datelike, Utc};
 use colored::{ColoredString, Colorize};
 use textwrap::{wrap, Options};
 
@@ -50,6 +50,19 @@ fn relative_time(timestamp: &str) -> String {
         format!("{}m ago", minutes)
     } else {
         "just now".to_string()
+    }
+}
+
+/// Format a timestamp as compact date (e.g., "Dec 22" or "Dec 22 '23" for previous years)
+fn compact_date(timestamp: &str) -> String {
+    let Ok(dt) = DateTime::parse_from_rfc3339(timestamp) else {
+        return String::new();
+    };
+    let now = Utc::now();
+    if dt.year() == now.year() {
+        dt.format("%b %d").to_string()
+    } else {
+        dt.format("%b %d '%y").to_string()
     }
 }
 
@@ -332,24 +345,29 @@ pub fn print_issue_row(issue: &Issue, comment_count: Option<usize>) {
         Some(count) => format!(" 💬{}", count),
     };
 
+    // Format created date
+    let date_str = compact_date(&issue.created_at);
+
     if tty {
         println!(
-            "{} {:>5}  {}{}{}{}",
+            "{} {:>5}  {}{}{}  {}{}",
             state_char,
             format!("#{}", issue.number).dimmed(),
             issue.title,
             labels_str,
             goal_str.cyan(),
+            date_str.dimmed(),
             comment_str.dimmed()
         );
     } else {
         println!(
-            "{} #{:<5}  {}{}{}{}",
+            "{} #{:<5}  {}{}{}  {}{}",
             state_char,
             issue.number,
             issue.title,
             labels_str,
             goal_str,
+            date_str,
             comment_str
         );
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -37,17 +37,29 @@ pub fn detect_git_dir() -> Result<PathBuf> {
     Ok(canonical)
 }
 
-/// Get the absolute path to the git repository root (working directory)
+/// Get the absolute path to the main git repository root (working directory)
+///
+/// For worktrees, this returns the main repository path (not the worktree path).
+/// This ensures that repo links work correctly from any worktree.
 pub fn detect_repo_path() -> Result<String> {
     let repo = discover_repo()?;
-    let workdir = repo
-        .workdir()
-        .ok_or_else(|| anyhow!("Bare repository has no working directory"))?;
-    // workdir() may return relative path, canonicalize to absolute
-    let canonical = workdir
+
+    // Use common_dir to get the main repo's .git directory
+    // For main repo: common_dir == git_dir == /path/to/repo/.git
+    // For worktree: common_dir == /path/to/main/repo/.git (with /../.. that needs resolving)
+    let common_dir = repo.common_dir();
+
+    // Canonicalize first to resolve any /../.. components
+    let canonical_git_dir = common_dir
         .canonicalize()
-        .map_err(|e| anyhow!("Failed to resolve workdir path: {}", e))?;
-    Ok(canonical.to_string_lossy().to_string())
+        .map_err(|e| anyhow!("Failed to resolve common git dir: {}", e))?;
+
+    // Get parent of .git to find the main repo working directory
+    let main_repo_path = canonical_git_dir
+        .parent()
+        .ok_or_else(|| anyhow!("Could not find parent of git directory"))?;
+
+    Ok(main_repo_path.to_string_lossy().to_string())
 }
 
 /// Detect repository from git remote


### PR DESCRIPTION
## Summary
- Display created date in compact format (e.g., "Dec 27") in issue list
- Fix commands failing in worktrees with "repo not linked" error

## Changes
- `src/display.rs`: Add `compact_date()` function, update `print_issue_row()` to show date
- `src/repo.rs`: Use `common_dir()` instead of `workdir()` to resolve main repo path

## Test plan
- [x] `cargo test` passes (78 tests)
- [x] `isq issue list` shows dates
- [x] Commands work from worktrees

Fixes #9
Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)