### PR TITLE
Fix Linear assign_self by storing user ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ cargo test
 - `src/db.rs` - SQLite cache
 - `src/cli/` - Commands
 
+## Database
+
+SQLite cache: `~/Library/Caches/isq/cache.db`
+
 ## Docs
 
 See `docs/` for context: STRATEGY.md (vision), ROADMAP.md (focus), DESIGN.md (architecture), CONTRIBUTING.md (issue creation).

--- a/src/db.rs
+++ b/src/db.rs
@@ -203,12 +203,29 @@ pub(crate) fn init_schema(conn: &Connection) -> Result<()> {
         conn.execute("ALTER TABLE rate_limit_state ADD COLUMN remaining INTEGER", [])?;
     }
 
-    // Migration: add username column to repo_links if it doesn't exist
-    let has_username: bool = conn
-        .prepare("SELECT username FROM repo_links LIMIT 0")
+    // Migration: rename username column to user_id (or add user_id if neither exists)
+    let has_user_id: bool = conn
+        .prepare("SELECT user_id FROM repo_links LIMIT 0")
         .is_ok();
-    if !has_username {
-        conn.execute("ALTER TABLE repo_links ADD COLUMN username TEXT", [])?;
+    if !has_user_id {
+        let has_username: bool = conn
+            .prepare("SELECT username FROM repo_links LIMIT 0")
+            .is_ok();
+        if has_username {
+            // Rename existing column
+            conn.execute("ALTER TABLE repo_links RENAME COLUMN username TO user_id", [])?;
+        } else {
+            // Add new column
+            conn.execute("ALTER TABLE repo_links ADD COLUMN user_id TEXT", [])?;
+        }
+    }
+
+    // Migration: add user_name column to repo_links if it doesn't exist
+    let has_user_name: bool = conn
+        .prepare("SELECT user_name FROM repo_links LIMIT 0")
+        .is_ok();
+    if !has_user_name {
+        conn.execute("ALTER TABLE repo_links ADD COLUMN user_name TEXT", [])?;
     }
 
     // Migration: add assignees column to issues if it doesn't exist
@@ -839,13 +856,16 @@ pub struct RepoLink {
     pub forge_type: String,
     pub forge_repo: String,
     pub display_name: Option<String>,
-    pub username: Option<String>,
+    /// The forge's native user identifier (GitHub username / Linear user UUID)
+    pub user_id: Option<String>,
+    /// User's display name for filtering (matches issue.assignees)
+    pub user_name: Option<String>,
 }
 
 /// Get the link for a repo path
 pub fn get_repo_link(conn: &Connection, repo_path: &str) -> Result<Option<RepoLink>> {
     let mut stmt = conn.prepare(
-        "SELECT repo_path, forge_type, forge_repo, display_name, username, created_at FROM repo_links WHERE repo_path = ?",
+        "SELECT repo_path, forge_type, forge_repo, display_name, user_id, user_name, created_at FROM repo_links WHERE repo_path = ?",
     )?;
 
     let mut rows = stmt.query(params![repo_path])?;
@@ -855,7 +875,8 @@ pub fn get_repo_link(conn: &Connection, repo_path: &str) -> Result<Option<RepoLi
             forge_type: row.get(1)?,
             forge_repo: row.get(2)?,
             display_name: row.get(3)?,
-            username: row.get(4)?,
+            user_id: row.get(4)?,
+            user_name: row.get(5)?,
         }))
     } else {
         Ok(None)
@@ -869,13 +890,14 @@ pub fn set_repo_link(
     forge_type: &str,
     forge_repo: &str,
     display_name: Option<&str>,
-    username: Option<&str>,
+    user_id: Option<&str>,
+    user_name: Option<&str>,
 ) -> Result<()> {
     conn.execute(
-        "INSERT INTO repo_links (repo_path, forge_type, forge_repo, display_name, username, created_at)
-         VALUES (?, ?, ?, ?, ?, datetime('now'))
-         ON CONFLICT(repo_path) DO UPDATE SET forge_type = ?, forge_repo = ?, display_name = ?, username = ?",
-        params![repo_path, forge_type, forge_repo, display_name, username, forge_type, forge_repo, display_name, username],
+        "INSERT INTO repo_links (repo_path, forge_type, forge_repo, display_name, user_id, user_name, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+         ON CONFLICT(repo_path) DO UPDATE SET forge_type = ?, forge_repo = ?, display_name = ?, user_id = ?, user_name = ?",
+        params![repo_path, forge_type, forge_repo, display_name, user_id, user_name, forge_type, forge_repo, display_name, user_id, user_name],
     )?;
     Ok(())
 }
@@ -1786,7 +1808,7 @@ mod tests {
     fn test_set_and_get_repo_link() {
         let conn = test_db();
 
-        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None).unwrap();
+        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None, None).unwrap();
 
         let link = get_repo_link(&conn, "/path/to/repo").unwrap();
         assert!(link.is_some());
@@ -1807,8 +1829,8 @@ mod tests {
     fn test_set_repo_link_updates_existing() {
         let conn = test_db();
 
-        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None).unwrap();
-        set_repo_link(&conn, "/path/to/repo", "linear", "team-id", None, None).unwrap();
+        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None, None).unwrap();
+        set_repo_link(&conn, "/path/to/repo", "linear", "team-id", None, None, None).unwrap();
 
         let link = get_repo_link(&conn, "/path/to/repo").unwrap().unwrap();
         assert_eq!(link.forge_type, "linear");
@@ -1819,7 +1841,7 @@ mod tests {
     fn test_remove_repo_link() {
         let conn = test_db();
 
-        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None).unwrap();
+        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, None, None).unwrap();
         remove_repo_link(&conn, "/path/to/repo").unwrap();
 
         let link = get_repo_link(&conn, "/path/to/repo").unwrap();
@@ -1835,13 +1857,14 @@ mod tests {
     }
 
     #[test]
-    fn test_repo_link_with_username() {
+    fn test_repo_link_with_user_id_and_name() {
         let conn = test_db();
 
-        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, Some("testuser")).unwrap();
+        set_repo_link(&conn, "/path/to/repo", "github", "owner/repo", None, Some("user-id-123"), Some("testuser")).unwrap();
 
         let link = get_repo_link(&conn, "/path/to/repo").unwrap().unwrap();
-        assert_eq!(link.username, Some("testuser".to_string()));
+        assert_eq!(link.user_id, Some("user-id-123".to_string()));
+        assert_eq!(link.user_name, Some("testuser".to_string()));
     }
 
     // === Rate Limit Budget Tests ===

--- a/src/forges/github.rs
+++ b/src/forges/github.rs
@@ -206,8 +206,8 @@ pub async fn link(repo_path: &str, _args: &LinkArgs) -> Result<LinkResult> {
     println!("Syncing {}...", display_name);
     let issues_result = client.list_issues_internal(&repo, None).await?;
 
-    // Save to database (PRs already filtered by list_issues_internal)
-    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &repo.full_name(), Some(&display_name), Some(&username))?;
+    // Save to database (for GitHub, username serves as both user_id and user_name)
+    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &repo.full_name(), Some(&display_name), Some(&username), Some(&username))?;
     db::save_issues(&conn, &repo.full_name(), &issues_result.items, true, issues_result.is_complete)?;
     db::add_watched_repo(&conn, repo_path)?;
 

--- a/src/forges/linear.rs
+++ b/src/forges/linear.rs
@@ -296,10 +296,10 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
 
     let client = LinearClient::new(token);
 
-    // Verify authentication
-    let username = client.get_viewer().await?;
+    // Verify authentication - get user ID for assignment and display name for printing
+    let (user_id, user_display_name) = client.get_viewer().await?;
     if is_new_auth {
-        println!("✓ Authenticated as {}", username);
+        println!("✓ Authenticated as {}", user_display_name);
     }
 
     // List teams
@@ -358,8 +358,8 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
     println!("Syncing {}...", team.name);
     let issues_result = client.list_team_issues_internal(&team.id, None).await?;
 
-    // Save to database
-    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &forge_repo, Some(&display_name), Some(&username))?;
+    // Save to database (user_id for API calls, user_display_name for --mine filter)
+    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &forge_repo, Some(&display_name), Some(&user_id), Some(&user_display_name))?;
     db::save_issues(&conn, &forge_repo, &issues_result.items, true, issues_result.is_complete)?;
     db::add_watched_repo(&conn, repo_path)?;
 
@@ -457,6 +457,7 @@ pub struct LinearOrganization {
 
 #[derive(Deserialize)]
 struct LinearUser {
+    id: String,
     #[serde(rename = "displayName")]
     display_name: String,
 }
@@ -861,18 +862,19 @@ impl LinearClient {
         }
     }
 
-    /// Get the authenticated user
-    pub async fn get_viewer(&self) -> Result<String> {
+    /// Get the authenticated user's ID and display name
+    pub async fn get_viewer(&self) -> Result<(String, String)> {
         let query = r#"
             query {
                 viewer {
+                    id
                     displayName
                 }
             }
         "#;
 
         let response: ViewerResponse = self.query(query, None).await?;
-        Ok(response.viewer.display_name)
+        Ok((response.viewer.id, response.viewer.display_name))
     }
 
     /// List all teams
@@ -1036,6 +1038,30 @@ impl LinearClient {
             .into_iter()
             .find(|u| u.name.to_lowercase() == name_lower || u.email.to_lowercase() == name_lower)
             .ok_or_else(|| anyhow::anyhow!("User '{}' not found", name))
+    }
+
+    /// Assign issue by user ID directly (no name lookup)
+    async fn assign_issue_by_id(&self, team_id: &str, issue_number: u64, user_id: &str) -> Result<()> {
+        let issue = self.get_issue_by_number(team_id, issue_number).await?;
+
+        let query = r#"
+            mutation($issueId: String!, $assigneeId: String!) {
+                issueUpdate(id: $issueId, input: { assigneeId: $assigneeId }) {
+                    success
+                }
+            }
+        "#;
+
+        let variables = serde_json::json!({
+            "issueId": issue.id,
+            "assigneeId": user_id
+        });
+
+        let response: IssueUpdateResponse = self.query(query, Some(variables)).await?;
+        if !response.issue_update.success {
+            anyhow::bail!("Failed to assign issue");
+        }
+        Ok(())
     }
 
     /// Get labels by name for a team
@@ -1691,27 +1717,9 @@ impl Forge for LinearClient {
     }
 
     async fn assign_issue(&self, repo: &Repo, issue_number: u64, assignee: &str) -> Result<()> {
-        let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
+        // CLI path: look up user by name/email to get their ID
         let user = self.get_user_by_name(assignee).await?;
-
-        let query = r#"
-            mutation($issueId: String!, $assigneeId: String!) {
-                issueUpdate(id: $issueId, input: { assigneeId: $assigneeId }) {
-                    success
-                }
-            }
-        "#;
-
-        let variables = serde_json::json!({
-            "issueId": issue.id,
-            "assigneeId": user.id
-        });
-
-        let response: IssueUpdateResponse = self.query(query, Some(variables)).await?;
-        if !response.issue_update.success {
-            anyhow::bail!("Failed to assign issue");
-        }
-        Ok(())
+        self.assign_issue_by_id(&repo.name, issue_number, &user.id).await
     }
 
     async fn list_all_comments(&self, repo: &Repo) -> Result<FetchResult<crate::db::Comment>> {
@@ -1787,7 +1795,7 @@ impl Forge for LinearClient {
         }
     }
 
-    async fn handle_on_start(&self, repo: &Repo, issue_number: u64, config: &toml::Value, username: Option<&str>) -> Result<()> {
+    async fn handle_on_start(&self, repo: &Repo, issue_number: u64, config: &toml::Value, user_id: Option<&str>) -> Result<()> {
         // Parse Linear-specific config from opaque toml::Value
         let cfg: LinearOnStartConfig = config.clone().try_into().unwrap_or_default();
 
@@ -1796,10 +1804,10 @@ impl Forge for LinearClient {
             self.transition_issue(&repo.name, issue_number, transition).await?;
         }
 
-        // Assign to self if configured
+        // Assign to self if configured (user_id is the Linear user UUID)
         if cfg.assign_self {
-            if let Some(user) = username {
-                self.assign_issue(repo, issue_number, user).await?;
+            if let Some(id) = user_id {
+                self.assign_issue_by_id(&repo.name, issue_number, id).await?;
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,7 +602,7 @@ async fn cmd_start(id: u64) -> Result<()> {
     let repo_path_clone = repo_path.clone();
     let git_dir_str = git_dir.to_string_lossy().to_string();
     let forge_repo = link.forge_repo.clone();
-    let username = link.username.clone();
+    let user_id = link.user_id.clone();
 
     // Run DB association, setup script, and forge actions concurrently
     let db_future = async {
@@ -661,7 +661,7 @@ async fn cmd_start(id: u64) -> Result<()> {
 
                 // Handle on_start - forge interprets config and handles everything
                 // (labels, transitions, assign_self, etc. are all forge-specific)
-                if let Err(e) = forge.handle_on_start(&repo_struct, id, on_start, username.as_deref()).await {
+                if let Err(e) = forge.handle_on_start(&repo_struct, id, on_start, user_id.as_deref()).await {
                     if !is_offline_error(&e) {
                         eprintln!("on_start warning: {}", e);
                     }
@@ -910,9 +910,9 @@ async fn cmd_issue_list(
     // Touch repo to update last_accessed for daemon priority
     db::touch_repo(&conn, &repo_path)?;
 
-    // Determine username for --mine filter
-    let username = if mine {
-        link.username.clone()
+    // Determine user_name for --mine filter (matches issue.assignees)
+    let user_name = if mine {
+        link.user_name.clone()
     } else {
         None
     };
@@ -923,7 +923,7 @@ async fn cmd_issue_list(
         ids.as_deref(),
         label.as_deref(),
         state.as_deref(),
-        username.as_deref(),
+        user_name.as_deref(),
         unassigned,
         goal.as_deref(),
         &sort,


### PR DESCRIPTION
## Summary
- Fixes "User 'X' not found" error when using `assign_self = true` in Linear repos
- Root cause: Linear's `displayName` doesn't match the `name` field used for user lookup

## Changes
- Store both `user_id` (Linear UUID) for API mutations and `user_name` (display name) for `--mine` filter
- Add `assign_issue_by_id()` method for direct ID-based assignment in `handle_on_start`
- Rename `username` column to `user_id` for semantic clarity
- Add `user_name` column with migration

## Test plan
- [x] `cargo test` passes (93 tests)
- [x] Run `isq link linear` in a Linear-backed repo to store both values
- [x] Run `isq start <issue>` with `assign_self = true` in config
- [x] Verify `--mine` filter still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)