### PR TITLE
Fix panic when creating HTTP client in sandboxed environments

### DIFF
--- a/src/forges/github.rs
+++ b/src/forges/github.rs
@@ -11,7 +11,7 @@ use tokio::sync::{Mutex, Semaphore};
 
 use chrono::{DateTime, SecondsFormat, Utc};
 
-use super::{AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
+use super::{create_http_client, AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
 use crate::repo::Repo;
 use crate::{config, db, repo};
 
@@ -76,7 +76,7 @@ struct DeviceCodeResponse {
 /// Run the GitHub Device Flow for authentication
 /// Shows a code for the user to enter at github.com/login/device
 pub async fn oauth_flow() -> Result<TokenResponse> {
-    let client = reqwest::Client::new();
+    let client = create_http_client();
 
     // Step 1: Request device code
     let params = [
@@ -413,7 +413,7 @@ struct SearchResult {
 impl GitHubClient {
     pub fn new(token: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: create_http_client(),
             token,
         }
     }

--- a/src/forges/linear.rs
+++ b/src/forges/linear.rs
@@ -11,7 +11,7 @@ use sha2::{Digest, Sha256};
 
 use chrono::{DateTime, Utc};
 
-use super::{AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
+use super::{create_http_client, AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
 use crate::repo::Repo;
 use crate::{config, db, repo};
 
@@ -195,7 +195,7 @@ fn send_response(stream: &mut std::net::TcpStream, success: bool, message: &str)
 
 /// Exchange authorization code for access token
 async fn exchange_code(code: &str, code_verifier: &str) -> Result<TokenResponse> {
-    let client = reqwest::Client::new();
+    let client = create_http_client();
 
     let params = [
         ("grant_type", "authorization_code"),
@@ -243,7 +243,7 @@ pub async fn oauth_flow() -> Result<TokenResponse> {
 
 /// Refresh a Linear access token using a refresh token
 pub async fn refresh_token(refresh_token: &str) -> Result<TokenResponse> {
-    let client = reqwest::Client::new();
+    let client = create_http_client();
 
     let params = [
         ("grant_type", "refresh_token"),
@@ -772,7 +772,7 @@ struct ProjectUpdatePayload {
 impl LinearClient {
     pub fn new(token: String) -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: create_http_client(),
             token: RwLock::new(token),
         }
     }

--- a/src/forges/mod.rs
+++ b/src/forges/mod.rs
@@ -1,9 +1,11 @@
 mod github;
 mod linear;
 
+use std::panic;
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
+use reqwest::Client;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
@@ -15,6 +17,35 @@ use crate::repo::Repo;
 
 pub use github::GitHubClient;
 pub use linear::LinearClient;
+
+// ============================================================================
+// HTTP Client
+// ============================================================================
+
+/// Create a reqwest Client, falling back to no_proxy if system proxy detection panics.
+///
+/// On macOS, reqwest tries to read system proxy settings via the system-configuration
+/// crate. In sandboxed environments (e.g., Claude Code), this can panic because
+/// access to macOS system configuration is blocked. This function catches that panic
+/// and falls back to a client without system proxy support.
+///
+/// On Linux, proxy detection reads environment variables and never panics.
+pub fn create_http_client() -> Client {
+    // Try to create a client with system proxy support
+    let result = panic::catch_unwind(|| Client::new());
+
+    match result {
+        Ok(client) => client,
+        Err(_) => {
+            // System proxy detection panicked (likely sandboxed macOS)
+            // Fall back to a client without system proxy support
+            Client::builder()
+                .no_proxy()
+                .build()
+                .expect("Failed to create HTTP client without proxy")
+        }
+    }
+}
 
 // ============================================================================
 // Fetch Result


### PR DESCRIPTION
## Summary

- Add `create_http_client()` helper that catches panics from macOS system proxy detection
- Falls back to `no_proxy()` client when sandbox blocks system configuration access
- Preserves proxy support for normal users, gracefully degrades in sandboxes

## Root Cause

`reqwest::Client::new()` calls `system-configuration` crate on macOS to detect system proxies. In Claude Code's sandbox, this API access is blocked, causing a panic.

## Test plan

- [x] `cargo test` passes (93 tests)
- [x] Manual: Run `isq start <id>` in Claude Code sandbox mode

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)