### PR TITLE
Store GitHub token in keychain during link for daemon access

### DIFF
--- a/src/forges/github.rs
+++ b/src/forges/github.rs
@@ -183,7 +183,12 @@ pub async fn link(repo_path: &str, _args: &LinkArgs) -> Result<LinkResult> {
 
     // Try existing auth first, fall back to OAuth
     let (token, auth_method) = match AUTH.get_token() {
-        Ok(t) => (t, "stored"),
+        Ok(t) => {
+            // Store in keychain so daemon can access
+            // (gh CLI isn't available from launchd)
+            AUTH.store_credential(&t, None, None)?;
+            (t, "existing")
+        }
         Err(_) => {
             let oauth_token = oauth_flow().await?;
             AUTH.store_credential(


### PR DESCRIPTION
## Summary

- Store GitHub token in keychain when `isq link github` gets it from `gh auth token`
- Enables daemon (running under launchd) to authenticate with GitHub
- Previously the daemon couldn't sync GitHub repos because it couldn't access `gh` CLI

## Root Cause

The daemon runs under launchd which cannot execute shell commands like `gh auth token`. When `isq link github` succeeded via `gh`, the token was used but never stored in keychain, leaving the daemon with no way to authenticate.

## Test plan

- [x] `cargo test` passes (93 tests)
- [x] Clear GitHub keychain: `security delete-generic-password -s isq -a github`
- [x] Run `isq link github` - token stored in keychain
- [x] Restart daemon - GitHub syncs successfully
- [x] Close issue via `gh`, wait for sync - local state updated to closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)