### PR TITLE
Refactor Forge trait to use String IDs instead of u64

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -64,8 +64,8 @@ pub enum Commands {
 
     /// Start working on an issue (creates worktree)
     Start {
-        /// Issue number
-        id: u64,
+        /// Issue ID (e.g., 123 or DEV-123)
+        id: String,
     },
 
     /// Clean up current worktree (remove worktree, clear association)
@@ -279,8 +279,8 @@ pub enum GoalCommands {
 
     /// Assign an issue to a goal
     Assign {
-        /// Issue number
-        issue: u64,
+        /// Issue ID (e.g., 123 or DEV-123)
+        issue: String,
 
         /// Goal name or ID
         goal: String,

--- a/src/cli/goals.rs
+++ b/src/cli/goals.rs
@@ -124,7 +124,7 @@ pub async fn cmd_create(
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: None,
+                    issue_id: None,
                     message: format!("Created goal: {}", goal.name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
@@ -159,7 +159,7 @@ pub async fn cmd_create(
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: None,
+                    issue_id: None,
                     message: format!("Queued: create goal {}", name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
@@ -178,7 +178,7 @@ pub async fn cmd_create(
     Ok(())
 }
 
-pub async fn cmd_assign(issue: u64, goal_name: String, json: bool) -> Result<()> {
+pub async fn cmd_assign(issue_id: &str, goal_name: String, json: bool) -> Result<()> {
     let start = Instant::now();
     let repo_path = repo::detect_repo_path()?;
     let (forge, link) = get_forge_for_repo(&repo_path)?;
@@ -201,22 +201,23 @@ pub async fn cmd_assign(issue: u64, goal_name: String, json: bool) -> Result<()>
         name: parts[1].to_string(),
     };
 
-    match forge.assign_to_goal(&repo_struct, issue, &goal.id).await {
+    let issue_display = crate::display::format_issue_id(issue_id);
+    match forge.assign_to_goal(&repo_struct, issue_id, &goal.id).await {
         Ok(()) => {
             let elapsed = start.elapsed();
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue),
-                    message: format!("Assigned #{} to goal '{}'", issue, goal.name),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Assigned {} to goal '{}'", issue_display, goal.name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
-                    "✓ Assigned #{} to goal '{}' ({:.0}ms)",
-                    issue,
+                    "✓ Assigned {} to goal '{}' ({:.0}ms)",
+                    issue_display,
                     goal.name,
                     elapsed.as_millis()
                 );
@@ -225,7 +226,7 @@ pub async fn cmd_assign(issue: u64, goal_name: String, json: bool) -> Result<()>
         Err(e) if is_offline_error(&e) => {
             let elapsed = start.elapsed();
             let payload = serde_json::json!({
-                "issue_number": issue,
+                "issue_id": issue_id,
                 "goal_id": goal.id,
             });
             db::queue_op(
@@ -239,15 +240,15 @@ pub async fn cmd_assign(issue: u64, goal_name: String, json: bool) -> Result<()>
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: Some(issue),
-                    message: format!("Queued: assign #{} to '{}'", issue, goal.name),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Queued: assign {} to '{}'", issue_display, goal.name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
-                    "✓ Queued: assign #{} to '{}' (offline, {:.0}ms)",
-                    issue,
+                    "✓ Queued: assign {} to '{}' (offline, {:.0}ms)",
+                    issue_display,
                     goal.name,
                     elapsed.as_millis()
                 );
@@ -286,7 +287,7 @@ pub async fn cmd_close(name: String, json: bool) -> Result<()> {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: None,
+                    issue_id: None,
                     message: format!("Closed goal '{}'", goal.name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
@@ -310,7 +311,7 @@ pub async fn cmd_close(name: String, json: bool) -> Result<()> {
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: None,
+                    issue_id: None,
                     message: format!("Queued: close goal '{}'", goal.name),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };

--- a/src/cli/issues.rs
+++ b/src/cli/issues.rs
@@ -35,10 +35,11 @@ pub async fn cmd_list(
     // Check if repo is linked
     let link = db::get_repo_link(&conn, &repo_path)?.ok_or_else(not_linked_error)?;
 
-    // Parse IDs if provided
-    let ids: Option<Vec<u64>> = id.map(|s| {
+    // Parse IDs if provided (can be numeric like "123" or string like "DEV-123")
+    let ids: Option<Vec<String>> = id.map(|s| {
         s.split(',')
-            .filter_map(|id_str| id_str.trim().parse::<u64>().ok())
+            .map(|id_str| id_str.trim().to_string())
+            .filter(|s| !s.is_empty())
             .collect()
     });
 
@@ -120,10 +121,11 @@ pub async fn cmd_list(
             filtered
         } else {
             // Forge doesn't handle these opts, fall back to cache
+            let ids_refs: Option<Vec<&str>> = ids.as_ref().map(|v| v.iter().map(|s| s.as_str()).collect());
             db::load_issues_filtered(
                 &conn,
                 &link.forge_repo,
-                ids.as_deref(),
+                ids_refs.as_deref(),
                 label.as_deref(),
                 state.as_deref(),
                 user_name.as_deref(),
@@ -134,10 +136,11 @@ pub async fn cmd_list(
         }
     } else {
         // No opts, use normal cache path
+        let ids_refs: Option<Vec<&str>> = ids.as_ref().map(|v| v.iter().map(|s| s.as_str()).collect());
         db::load_issues_filtered(
             &conn,
             &link.forge_repo,
-            ids.as_deref(),
+            ids_refs.as_deref(),
             label.as_deref(),
             state.as_deref(),
             user_name.as_deref(),
@@ -169,18 +172,25 @@ pub fn cmd_show(id: &str, json_output: bool) -> Result<()> {
     let link = db::get_repo_link(&conn, &repo_path)?.ok_or_else(not_linked_error)?;
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        link.forge_repo.split('/').last().map(|s| s.to_string())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key.as_deref())?;
+    if link.forge_type == "jira" {
+        let project_key = link.forge_repo.split('/').last().unwrap_or("");
+        if id.contains('-') {
+            let prefix = id.split('-').next().unwrap_or("");
+            if !prefix.eq_ignore_ascii_case(project_key) {
+                anyhow::bail!(
+                    "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
+                    id, prefix, project_key
+                );
+            }
+        }
+    }
+    let issue_id = id;
 
     // Touch repo to update last_accessed for daemon priority
     db::touch_repo(&conn, &repo_path)?;
 
-    let issue = db::load_issue(&conn, &link.forge_repo, issue_number)?;
-    let comments = db::load_comments(&conn, &link.forge_repo, issue_number)?;
+    let issue = db::load_issue(&conn, &link.forge_repo, issue_id)?;
+    let comments = db::load_comments(&conn, &link.forge_repo, issue_id)?;
     let elapsed = start.elapsed();
 
     match issue {
@@ -266,19 +276,20 @@ pub async fn cmd_create(
     match forge.create_issue(&repo_struct, req).await {
         Ok(issue) => {
             let elapsed = start.elapsed();
+            let issue_id_display = display::format_issue_id(&issue.id);
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue.number),
-                    message: format!("Created #{} {}", issue.number, issue.title),
+                    issue_id: Some(issue.id.clone()),
+                    message: format!("Created {} {}", issue_id_display, issue.title),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
-                    "✓ Created #{} {} ({:.0}ms)",
-                    issue.number,
+                    "✓ Created {} {} ({:.0}ms)",
+                    issue_id_display,
                     issue.title,
                     elapsed.as_millis()
                 );
@@ -297,7 +308,7 @@ pub async fn cmd_create(
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: None,
+                    issue_id: None,
                     message: format!("Queued: {}", title),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
@@ -333,50 +344,60 @@ pub async fn cmd_comment(id: &str, message: String, json: bool) -> Result<()> {
     };
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        Some(repo_struct.name.as_str())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key)?;
+    if link.forge_type == "jira" {
+        let project_key = repo_struct.name.as_str();
+        // Validate prefix if ID contains one
+        if id.contains('-') {
+            let prefix = id.split('-').next().unwrap_or("");
+            if !prefix.eq_ignore_ascii_case(project_key) {
+                anyhow::bail!(
+                    "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
+                    id, prefix, project_key
+                );
+            }
+        }
+    }
+    let issue_id = id;
 
-    match forge.create_comment(&repo_struct, issue_number, &message).await {
+    match forge.create_comment(&repo_struct, issue_id, &message).await {
         Ok(()) => {
             let elapsed = start.elapsed();
+            let issue_display = display::format_issue_id(issue_id);
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue_number),
-                    message: format!("Comment added to {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Comment added to {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
-                println!("✓ Comment added to {} ({:.0}ms)", id, elapsed.as_millis());
+                println!("✓ Comment added to {} ({:.0}ms)", issue_display, elapsed.as_millis());
             }
         }
         Err(e) if is_offline_error(&e) => {
             let elapsed = start.elapsed();
             let payload = serde_json::json!({
-                "issue_number": issue_number,
+                "issue_id": issue_id,
                 "body": message,
             });
             let conn = db::open()?;
             db::queue_op(&conn, &link.forge_repo, "comment", &payload.to_string())?;
+            let issue_display = display::format_issue_id(issue_id);
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: Some(issue_number),
-                    message: format!("Queued: comment on {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Queued: comment on {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
                     "✓ Queued: comment on {} (offline, {:.0}ms)",
-                    id,
+                    issue_display,
                     elapsed.as_millis()
                 );
             }
@@ -404,47 +425,55 @@ pub async fn cmd_close(id: &str, json: bool) -> Result<()> {
     };
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        Some(repo_struct.name.as_str())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key)?;
+    if link.forge_type == "jira" {
+        let project_key = repo_struct.name.as_str();
+        if id.contains('-') {
+            let prefix = id.split('-').next().unwrap_or("");
+            if !prefix.eq_ignore_ascii_case(project_key) {
+                anyhow::bail!(
+                    "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
+                    id, prefix, project_key
+                );
+            }
+        }
+    }
+    let issue_id = id;
+    let issue_display = display::format_issue_id(issue_id);
 
-    match forge.close_issue(&repo_struct, issue_number).await {
+    match forge.close_issue(&repo_struct, issue_id).await {
         Ok(()) => {
             let elapsed = start.elapsed();
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue_number),
-                    message: format!("Closed {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Closed {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
-                println!("✓ Closed {} ({:.0}ms)", id, elapsed.as_millis());
+                println!("✓ Closed {} ({:.0}ms)", issue_display, elapsed.as_millis());
             }
         }
         Err(e) if is_offline_error(&e) => {
             let elapsed = start.elapsed();
-            let payload = serde_json::json!({ "issue_number": issue_number });
+            let payload = serde_json::json!({ "issue_id": issue_id });
             let conn = db::open()?;
             db::queue_op(&conn, &link.forge_repo, "close", &payload.to_string())?;
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: Some(issue_number),
-                    message: format!("Queued: close {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Queued: close {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
                     "✓ Queued: close {} (offline, {:.0}ms)",
-                    id,
+                    issue_display,
                     elapsed.as_millis()
                 );
             }
@@ -472,47 +501,55 @@ pub async fn cmd_reopen(id: &str, json: bool) -> Result<()> {
     };
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        Some(repo_struct.name.as_str())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key)?;
+    if link.forge_type == "jira" {
+        let project_key = repo_struct.name.as_str();
+        if id.contains('-') {
+            let prefix = id.split('-').next().unwrap_or("");
+            if !prefix.eq_ignore_ascii_case(project_key) {
+                anyhow::bail!(
+                    "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
+                    id, prefix, project_key
+                );
+            }
+        }
+    }
+    let issue_id = id;
+    let issue_display = display::format_issue_id(issue_id);
 
-    match forge.reopen_issue(&repo_struct, issue_number).await {
+    match forge.reopen_issue(&repo_struct, issue_id).await {
         Ok(()) => {
             let elapsed = start.elapsed();
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue_number),
-                    message: format!("Reopened {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Reopened {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
-                println!("✓ Reopened {} ({:.0}ms)", id, elapsed.as_millis());
+                println!("✓ Reopened {} ({:.0}ms)", issue_display, elapsed.as_millis());
             }
         }
         Err(e) if is_offline_error(&e) => {
             let elapsed = start.elapsed();
-            let payload = serde_json::json!({ "issue_number": issue_number });
+            let payload = serde_json::json!({ "issue_id": issue_id });
             let conn = db::open()?;
             db::queue_op(&conn, &link.forge_repo, "reopen", &payload.to_string())?;
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: Some(issue_number),
-                    message: format!("Queued: reopen {}", id),
+                    issue_id: Some(issue_id.to_string()),
+                    message: format!("Queued: reopen {}", issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else {
                 println!(
                     "✓ Queued: reopen {} (offline, {:.0}ms)",
-                    id,
+                    issue_display,
                     elapsed.as_millis()
                 );
             }
@@ -540,24 +577,32 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
     };
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        Some(repo_struct.name.as_str())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key)?;
+    if link.forge_type == "jira" {
+        let project_key = repo_struct.name.as_str();
+        if id.contains('-') {
+            let prefix = id.split('-').next().unwrap_or("");
+            if !prefix.eq_ignore_ascii_case(project_key) {
+                anyhow::bail!(
+                    "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
+                    id, prefix, project_key
+                );
+            }
+        }
+    }
+    let issue_id = id;
+    let issue_display = display::format_issue_id(issue_id);
 
     match action.as_str() {
         "add" => {
-            match forge.add_label(&repo_struct, issue_number, &label).await {
+            match forge.add_label(&repo_struct, issue_id, &label).await {
                 Ok(()) => {
                     let elapsed = start.elapsed();
                     if json {
                         let result = WriteResult {
                             success: true,
                             queued: false,
-                            issue_number: Some(issue_number),
-                            message: format!("Added label '{}' to {}", label, id),
+                            issue_id: Some(issue_id.to_string()),
+                            message: format!("Added label '{}' to {}", label, issue_display),
                             elapsed_ms: elapsed.as_millis() as u64,
                         };
                         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -565,7 +610,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         println!(
                             "✓ Added label '{}' to {} ({:.0}ms)",
                             label,
-                            id,
+                            issue_display,
                             elapsed.as_millis()
                         );
                     }
@@ -573,7 +618,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                 Err(e) if is_offline_error(&e) => {
                     let elapsed = start.elapsed();
                     let payload = serde_json::json!({
-                        "issue_number": issue_number,
+                        "issue_id": issue_id,
                         "label": label,
                     });
                     let conn = db::open()?;
@@ -582,8 +627,8 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         let result = WriteResult {
                             success: true,
                             queued: true,
-                            issue_number: Some(issue_number),
-                            message: format!("Queued: add label '{}' to {}", label, id),
+                            issue_id: Some(issue_id.to_string()),
+                            message: format!("Queued: add label '{}' to {}", label, issue_display),
                             elapsed_ms: elapsed.as_millis() as u64,
                         };
                         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -591,7 +636,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         println!(
                             "✓ Queued: add label '{}' to {} (offline, {:.0}ms)",
                             label,
-                            id,
+                            issue_display,
                             elapsed.as_millis()
                         );
                     }
@@ -600,15 +645,15 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
             }
         }
         "remove" => {
-            match forge.remove_label(&repo_struct, issue_number, &label).await {
+            match forge.remove_label(&repo_struct, issue_id, &label).await {
                 Ok(()) => {
                     let elapsed = start.elapsed();
                     if json {
                         let result = WriteResult {
                             success: true,
                             queued: false,
-                            issue_number: Some(issue_number),
-                            message: format!("Removed label '{}' from {}", label, id),
+                            issue_id: Some(issue_id.to_string()),
+                            message: format!("Removed label '{}' from {}", label, issue_display),
                             elapsed_ms: elapsed.as_millis() as u64,
                         };
                         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -616,7 +661,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         println!(
                             "✓ Removed label '{}' from {} ({:.0}ms)",
                             label,
-                            id,
+                            issue_display,
                             elapsed.as_millis()
                         );
                     }
@@ -624,7 +669,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                 Err(e) if is_offline_error(&e) => {
                     let elapsed = start.elapsed();
                     let payload = serde_json::json!({
-                        "issue_number": issue_number,
+                        "issue_id": issue_id,
                         "label": label,
                     });
                     let conn = db::open()?;
@@ -638,8 +683,8 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         let result = WriteResult {
                             success: true,
                             queued: true,
-                            issue_number: Some(issue_number),
-                            message: format!("Queued: remove label '{}' from {}", label, id),
+                            issue_id: Some(issue_id.to_string()),
+                            message: format!("Queued: remove label '{}' from {}", label, issue_display),
                             elapsed_ms: elapsed.as_millis() as u64,
                         };
                         println!("{}", serde_json::to_string_pretty(&result)?);
@@ -647,7 +692,7 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool) -> R
                         println!(
                             "✓ Queued: remove label '{}' from {} (offline, {:.0}ms)",
                             label,
-                            id,
+                            issue_display,
                             elapsed.as_millis()
                         );
                     }
@@ -680,22 +725,23 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
     };
 
     // For JIRA, validate issue key prefix matches linked project
-    let project_key = if link.forge_type == "jira" {
-        Some(repo_struct.name.as_str())
-    } else {
-        None
-    };
-    let issue_number = parse_issue_number(id, project_key)?;
+    if link.forge_type == "jira" {
+        let project_key = repo_struct.name.as_str();
+        // Validate the issue key prefix matches the linked project
+        parse_issue_number(id, Some(project_key))?;
+    }
 
-    match forge.assign_issue(&repo_struct, issue_number, &user).await {
+    let issue_display = display::format_issue_id(id);
+
+    match forge.assign_issue(&repo_struct, id, &user).await {
         Ok(()) => {
             let elapsed = start.elapsed();
             if json {
                 let result = WriteResult {
                     success: true,
                     queued: false,
-                    issue_number: Some(issue_number),
-                    message: format!("Assigned @{} to {}", user, id),
+                    issue_id: Some(id.to_string()),
+                    message: format!("Assigned @{} to {}", user, issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
@@ -703,7 +749,7 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
                 println!(
                     "✓ Assigned @{} to {} ({:.0}ms)",
                     user,
-                    id,
+                    issue_display,
                     elapsed.as_millis()
                 );
             }
@@ -711,7 +757,7 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
         Err(e) if is_offline_error(&e) => {
             let elapsed = start.elapsed();
             let payload = serde_json::json!({
-                "issue_number": issue_number,
+                "issue_id": id,
                 "assignee": user,
             });
             let conn = db::open()?;
@@ -720,8 +766,8 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
                 let result = WriteResult {
                     success: true,
                     queued: true,
-                    issue_number: Some(issue_number),
-                    message: format!("Queued: assign @{} to {}", user, id),
+                    issue_id: Some(id.to_string()),
+                    message: format!("Queued: assign @{} to {}", user, issue_display),
                     elapsed_ms: elapsed.as_millis() as u64,
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
@@ -729,7 +775,7 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
                 println!(
                     "✓ Queued: assign @{} to {} (offline, {:.0}ms)",
                     user,
-                    id,
+                    issue_display,
                     elapsed.as_millis()
                 );
             }
@@ -740,14 +786,14 @@ pub async fn cmd_assign(id: &str, user: String, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn print_issues(issues: &[Issue], comment_counts: &HashMap<u64, usize>) {
+fn print_issues(issues: &[Issue], comment_counts: &HashMap<String, usize>) {
     if issues.is_empty() {
         println!("No open issues.");
         return;
     }
 
     for issue in issues {
-        let count = comment_counts.get(&issue.number).copied();
+        let count = comment_counts.get(&issue.id).copied();
         display::print_issue_row(issue, count);
     }
 }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -11,7 +11,7 @@ pub struct WriteResult {
     pub success: bool,
     pub queued: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issue_number: Option<u64>,
+    pub issue_id: Option<String>,
     pub message: String,
     pub elapsed_ms: u64,
 }

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -35,10 +35,10 @@ pub fn cmd_home() -> Result<()> {
     let conn = db::open()?;
 
     match db::get_worktree_issue(&conn, &git_dir.to_string_lossy())? {
-        Some((forge_repo, issue_number)) => {
+        Some((forge_repo, issue_id)) => {
             let start = Instant::now();
-            let issue = db::load_issue(&conn, &forge_repo, issue_number as u64)?;
-            let comments = db::load_comments(&conn, &forge_repo, issue_number as u64)?;
+            let issue = db::load_issue(&conn, &forge_repo, &issue_id)?;
+            let comments = db::load_comments(&conn, &forge_repo, &issue_id)?;
             let elapsed = start.elapsed();
 
             match issue {
@@ -55,9 +55,10 @@ pub fn cmd_home() -> Result<()> {
                     }
                 }
                 None => {
+                    let issue_display = display::format_issue_id(&issue_id);
                     eprintln!(
-                        "Current issue #{} not in cache. Run `isq sync` to refresh.",
-                        issue_number
+                        "Current issue {} not in cache. Run `isq sync` to refresh.",
+                        issue_display
                     );
                     std::process::exit(1);
                 }
@@ -73,7 +74,7 @@ pub fn cmd_home() -> Result<()> {
     Ok(())
 }
 
-pub async fn cmd_start(id: u64) -> Result<()> {
+pub async fn cmd_start(id: String) -> Result<()> {
     let repo_path = repo::detect_repo_path()?;
     let conn = db::open()?;
 
@@ -81,10 +82,11 @@ pub async fn cmd_start(id: u64) -> Result<()> {
     let link = db::get_repo_link(&conn, &repo_path)?.ok_or_else(not_linked_error)?;
 
     // Load issue from cache (fast!)
-    let issue = db::load_issue(&conn, &link.forge_repo, id)?
-        .ok_or_else(|| anyhow::anyhow!("Issue #{} not found. Run `isq sync` first.", id))?;
+    let issue_display = display::format_issue_id(&id);
+    let issue = db::load_issue(&conn, &link.forge_repo, &id)?
+        .ok_or_else(|| anyhow::anyhow!("Issue {} not found. Run `isq sync` first.", issue_display))?;
 
-    // Create branch name: {number}-{slugified-title}
+    // Create branch name: {id}-{slugified-title}
     let branch = format!("{}-{}", id, repo::slugify(&issue.title));
 
     // Load and validate config BEFORE creating worktree (fail fast)
@@ -116,8 +118,11 @@ pub async fn cmd_start(id: u64) -> Result<()> {
     let user_id = link.user_id.clone();
 
     // Run DB association, setup script, and forge actions concurrently
+    let id_for_db = id.clone();
+    let id_for_setup = id.clone();
+    let id_for_forge = id.clone();
     let db_future =
-        async { db::set_worktree_issue(&conn, &git_dir_str, &forge_repo, id as i64) };
+        async { db::set_worktree_issue(&conn, &git_dir_str, &forge_repo, &id_for_db) };
 
     let setup_future = async {
         if let Some(ref cfg) = repo_config {
@@ -127,7 +132,7 @@ pub async fn cmd_start(id: u64) -> Result<()> {
                     &worktree_path_clone,
                     script,
                     std::path::Path::new(&repo_path_clone),
-                    id,
+                    &id_for_setup,
                 )
                 .await
                 {
@@ -177,7 +182,7 @@ pub async fn cmd_start(id: u64) -> Result<()> {
                 // Handle on_start - forge interprets config and handles everything
                 // (labels, transitions, assign_self, etc. are all forge-specific)
                 if let Err(e) = forge
-                    .handle_on_start(&repo_struct, id, on_start, user_id.as_deref())
+                    .handle_on_start(&repo_struct, &id_for_forge, on_start, user_id.as_deref())
                     .await
                 {
                     if !is_offline_error(&e) {
@@ -202,7 +207,7 @@ pub async fn cmd_start(id: u64) -> Result<()> {
     let _ = setup_result;
     let _ = forge_result;
 
-    println!("Issue #{}: \"{}\"", id, issue.title);
+    println!("Issue {}: \"{}\"", issue_display, issue.title);
 
     Ok(())
 }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -468,41 +468,67 @@ async fn execute_pending_op(
                 opts: std::collections::HashMap::new(),
             };
             let issue = forge.create_issue(repo, req).await?;
-            eprintln!("[daemon] Created #{} {}", issue.number, issue.title);
+            let issue_display = crate::display::format_issue_id(&issue.id);
+            eprintln!("[daemon] Created {} {}", issue_display, issue.title);
         }
         "comment" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
+            // Support both old issue_number and new issue_id keys
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
             let body = payload["body"].as_str().unwrap_or("");
-            forge.create_comment(repo, issue_number, body).await?;
-            eprintln!("[daemon] Added comment to #{}", issue_number);
+            forge.create_comment(repo, &issue_id, body).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Added comment to {}", issue_display);
         }
         "close" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
-            forge.close_issue(repo, issue_number).await?;
-            eprintln!("[daemon] Closed #{}", issue_number);
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
+            forge.close_issue(repo, &issue_id).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Closed {}", issue_display);
         }
         "reopen" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
-            forge.reopen_issue(repo, issue_number).await?;
-            eprintln!("[daemon] Reopened #{}", issue_number);
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
+            forge.reopen_issue(repo, &issue_id).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Reopened {}", issue_display);
         }
         "label_add" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
             let label = payload["label"].as_str().unwrap_or("");
-            forge.add_label(repo, issue_number, label).await?;
-            eprintln!("[daemon] Added label '{}' to #{}", label, issue_number);
+            forge.add_label(repo, &issue_id, label).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Added label '{}' to {}", label, issue_display);
         }
         "label_remove" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
             let label = payload["label"].as_str().unwrap_or("");
-            forge.remove_label(repo, issue_number, label).await?;
-            eprintln!("[daemon] Removed label '{}' from #{}", label, issue_number);
+            forge.remove_label(repo, &issue_id, label).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Removed label '{}' from {}", label, issue_display);
         }
         "assign" => {
-            let issue_number = payload["issue_number"].as_u64().unwrap_or(0);
+            let issue_id = payload["issue_id"].as_str()
+                .map(|s| s.to_string())
+                .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
+                .unwrap_or_default();
             let assignee = payload["assignee"].as_str().unwrap_or("");
-            forge.assign_issue(repo, issue_number, assignee).await?;
-            eprintln!("[daemon] Assigned @{} to #{}", assignee, issue_number);
+            forge.assign_issue(repo, &issue_id, assignee).await?;
+            let issue_display = crate::display::format_issue_id(&issue_id);
+            eprintln!("[daemon] Assigned @{} to {}", assignee, issue_display);
         }
         _ => {
             anyhow::bail!("Unknown op type: {}", op.op_type);

--- a/src/db/comments.rs
+++ b/src/db/comments.rs
@@ -10,7 +10,7 @@ use super::SyncResult;
 #[derive(Debug, Clone)]
 pub struct Comment {
     pub comment_id: String,
-    pub issue_number: u64,
+    pub issue_id: String,
     pub body: String,
     pub author: String,
     pub created_at: String,
@@ -51,12 +51,22 @@ pub fn save_comments(
             )
             .unwrap_or(false);
 
+        // Extract numeric part from issue ID for backward compatibility with 'issue_number' column
+        // For "123" → 123, for "DEV-123" → 123
+        let issue_number: i64 = comment
+            .issue_id
+            .split('-')
+            .last()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
         // UPSERT the comment, clearing deleted flag if it was set
         tx.execute(
-            "INSERT INTO comments (forge_repo, issue_number, comment_id, body, author, created_at, updated_at, deleted, deleted_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL)
+            "INSERT INTO comments (forge_repo, issue_number, issue_id, comment_id, body, author, created_at, updated_at, deleted, deleted_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 0, NULL)
              ON CONFLICT(forge_repo, comment_id) DO UPDATE SET
                 issue_number = excluded.issue_number,
+                issue_id = excluded.issue_id,
                 body = excluded.body,
                 author = excluded.author,
                 created_at = excluded.created_at,
@@ -65,7 +75,8 @@ pub fn save_comments(
                 deleted_at = NULL",
             params![
                 forge_repo,
-                comment.issue_number as i64,
+                issue_number,
+                comment.issue_id,
                 comment.comment_id,
                 comment.body,
                 comment.author,
@@ -150,20 +161,19 @@ pub fn save_comments(
 pub fn load_comments(
     conn: &Connection,
     forge_repo: &str,
-    issue_number: u64,
+    issue_id: &str,
 ) -> Result<Vec<Comment>> {
     let mut stmt = conn.prepare(
-        "SELECT comment_id, issue_number, body, author, created_at, updated_at
-         FROM comments WHERE forge_repo = ? AND issue_number = ? AND deleted = 0
+        "SELECT comment_id, issue_id, body, author, created_at, updated_at
+         FROM comments WHERE forge_repo = ? AND issue_id = ? AND deleted = 0
          ORDER BY created_at ASC",
     )?;
 
     let comments = stmt
-        .query_map(params![forge_repo, issue_number as i64], |row| {
-            let num: i64 = row.get(1)?;
+        .query_map(params![forge_repo, issue_id], |row| {
             Ok(Comment {
                 comment_id: row.get(0)?,
-                issue_number: num as u64,
+                issue_id: row.get(1)?,
                 body: row.get(2)?,
                 author: row.get(3)?,
                 created_at: row.get(4)?,
@@ -175,26 +185,26 @@ pub fn load_comments(
     Ok(comments)
 }
 
-/// Count comments for each issue in a repo (returns map of issue_number -> count)
+/// Count comments for each issue in a repo (returns map of issue_id -> count)
 /// Excludes deleted comments
 pub fn count_comments_by_issue(
     conn: &Connection,
     forge_repo: &str,
-) -> Result<HashMap<u64, usize>> {
+) -> Result<HashMap<String, usize>> {
     let mut stmt = conn.prepare(
-        "SELECT issue_number, COUNT(*) FROM comments WHERE forge_repo = ? AND deleted = 0 GROUP BY issue_number",
+        "SELECT issue_id, COUNT(*) FROM comments WHERE forge_repo = ? AND deleted = 0 GROUP BY issue_id",
     )?;
 
     let mut counts = HashMap::new();
     let rows = stmt.query_map(params![forge_repo], |row| {
-        let num: i64 = row.get(0)?;
+        let id: String = row.get(0)?;
         let count: i64 = row.get(1)?;
-        Ok((num as u64, count as usize))
+        Ok((id, count as usize))
     })?;
 
     for row in rows {
-        let (num, count) = row?;
-        counts.insert(num, count);
+        let (id, count) = row?;
+        counts.insert(id, count);
     }
 
     Ok(counts)

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -54,18 +54,27 @@ pub fn save_issues(
         // Check if issue exists
         let exists: bool = tx
             .query_row(
-                "SELECT 1 FROM issues WHERE repo = ? AND number = ?",
-                params![repo, issue.number as i64],
+                "SELECT 1 FROM issues WHERE repo = ? AND issue_id = ?",
+                params![repo, issue.id],
                 |_| Ok(true),
             )
             .unwrap_or(false);
 
+        // Extract numeric part from issue ID for backward compatibility with 'number' column
+        // For "123" → 123, for "DEV-123" → 123
+        let number: i64 = issue
+            .id
+            .split('-')
+            .last()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+
         // UPSERT the issue, clearing deleted flag if it was set
         tx.execute(
-            "INSERT INTO issues (repo, number, key, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone, deleted, deleted_at)
+            "INSERT INTO issues (repo, number, issue_id, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone, deleted, deleted_at)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, 0, NULL)
-             ON CONFLICT(repo, number) DO UPDATE SET
-                key = excluded.key,
+             ON CONFLICT(repo, issue_id) DO UPDATE SET
+                number = excluded.number,
                 title = excluded.title,
                 body = excluded.body,
                 state = excluded.state,
@@ -82,8 +91,8 @@ pub fn save_issues(
                 deleted_at = NULL",
             params![
                 repo,
-                issue.number as i64,
-                issue.key,
+                number,
+                issue.id,
                 issue.title,
                 issue.body,
                 issue.state,
@@ -108,21 +117,21 @@ pub fn save_issues(
 
     // During full sync with complete fetch: mark missing issues as deleted
     let deleted = if full_sync && is_complete && !issues.is_empty() {
-        // Create temp table for seen issue numbers
+        // Create temp table for seen issue IDs
         tx.execute(
-            "CREATE TEMP TABLE IF NOT EXISTS seen_issues (number INTEGER PRIMARY KEY)",
+            "CREATE TEMP TABLE IF NOT EXISTS seen_issues (issue_id TEXT PRIMARY KEY)",
             [],
         )?;
         tx.execute("DELETE FROM seen_issues", [])?;
 
-        // Batch insert seen numbers (500 at a time to avoid SQL length limits)
+        // Batch insert seen IDs (500 at a time to avoid SQL length limits)
         for chunk in issues.chunks(500) {
             let placeholders: String = chunk.iter().map(|_| "(?)").collect::<Vec<_>>().join(",");
             let sql = format!(
-                "INSERT INTO seen_issues (number) VALUES {}",
+                "INSERT INTO seen_issues (issue_id) VALUES {}",
                 placeholders
             );
-            let params: Vec<i64> = chunk.iter().map(|i| i.number as i64).collect();
+            let params: Vec<&str> = chunk.iter().map(|i| i.id.as_str()).collect();
             tx.execute(&sql, rusqlite::params_from_iter(params))?;
         }
 
@@ -130,7 +139,7 @@ pub fn save_issues(
         let count = tx.execute(
             "UPDATE issues SET deleted = 1, deleted_at = datetime('now')
              WHERE repo = ? AND deleted = 0
-             AND number NOT IN (SELECT number FROM seen_issues)",
+             AND issue_id NOT IN (SELECT issue_id FROM seen_issues)",
             params![repo],
         )?;
 
@@ -214,7 +223,7 @@ pub fn load_issues(conn: &Connection, repo: &str) -> Result<Vec<Issue>> {
 pub fn load_issues_filtered(
     conn: &Connection,
     repo: &str,
-    ids: Option<&[u64]>,
+    ids: Option<&[&str]>,
     label: Option<&str>,
     state: Option<&str>,
     assignee: Option<&str>,
@@ -225,7 +234,7 @@ pub fn load_issues_filtered(
     // Build query dynamically based on filters
     // Always exclude deleted issues
     let mut sql = String::from(
-        "SELECT number, key, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone
+        "SELECT issue_id, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone
          FROM issues WHERE repo = ? AND deleted = 0",
     );
 
@@ -235,9 +244,9 @@ pub fn load_issues_filtered(
     if let Some(id_list) = ids {
         if !id_list.is_empty() {
             let placeholders: Vec<&str> = id_list.iter().map(|_| "?").collect();
-            sql.push_str(&format!(" AND number IN ({})", placeholders.join(",")));
+            sql.push_str(&format!(" AND issue_id IN ({})", placeholders.join(",")));
             for id in id_list {
-                params_vec.push(Box::new(*id as i64));
+                params_vec.push(Box::new(id.to_string()));
             }
         }
     }
@@ -271,10 +280,10 @@ pub fn load_issues_filtered(
 
     // Apply sort order
     let order_by = match sort {
-        "newest" => "number DESC",
-        "oldest" => "number ASC",
+        "newest" => "created_at DESC",
+        "oldest" => "created_at ASC",
         "updated" => "updated_at DESC",
-        _ => "priority ASC, number DESC", // default: priority
+        _ => "priority ASC, created_at DESC", // default: priority
     };
     sql.push_str(" ORDER BY ");
     sql.push_str(order_by);
@@ -285,30 +294,27 @@ pub fn load_issues_filtered(
 
     let issues = stmt
         .query_map(params_refs.as_slice(), |row| {
-            let number: i64 = row.get(0)?;
-            let key: Option<String> = row.get(1)?;
-            let labels_json: String = row.get(6)?;
+            let labels_json: String = row.get(5)?;
             let labels = parse_labels_json(&labels_json);
-            let assignees_json: String = row.get::<_, Option<String>>(7)?.unwrap_or_default();
+            let assignees_json: String = row.get::<_, Option<String>>(6)?.unwrap_or_default();
             let assignees: Vec<String> =
                 serde_json::from_str(&assignees_json).unwrap_or_default();
-            let priority: i64 = row.get::<_, Option<i64>>(8)?.unwrap_or(4);
+            let priority: i64 = row.get::<_, Option<i64>>(7)?.unwrap_or(4);
 
             Ok(Issue {
-                number: number as u64,
-                key,
-                title: row.get(2)?,
-                body: row.get(3)?,
-                state: row.get(4)?,
-                author: row.get(5)?,
+                id: row.get(0)?,
+                title: row.get(1)?,
+                body: row.get(2)?,
+                state: row.get(3)?,
+                author: row.get(4)?,
                 labels,
                 assignees,
                 priority: priority as u8,
-                priority_label: row.get(9)?,
-                created_at: row.get(10)?,
-                updated_at: row.get(11)?,
-                url: row.get(12)?,
-                milestone: row.get(13)?,
+                priority_label: row.get(8)?,
+                created_at: row.get(9)?,
+                updated_at: row.get(10)?,
+                url: row.get(11)?,
+                milestone: row.get(12)?,
             })
         })?
         .collect::<Result<Vec<_>, _>>()?;
@@ -317,38 +323,35 @@ pub fn load_issues_filtered(
 }
 
 /// Load a single issue from cache (excludes deleted issues)
-pub fn load_issue(conn: &Connection, repo: &str, number: u64) -> Result<Option<Issue>> {
+pub fn load_issue(conn: &Connection, repo: &str, issue_id: &str) -> Result<Option<Issue>> {
     let mut stmt = conn.prepare(
-        "SELECT number, key, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone
-         FROM issues WHERE repo = ? AND number = ? AND deleted = 0",
+        "SELECT issue_id, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone
+         FROM issues WHERE repo = ? AND issue_id = ? AND deleted = 0",
     )?;
 
-    let mut rows = stmt.query(params![repo, number as i64])?;
+    let mut rows = stmt.query(params![repo, issue_id])?;
 
     if let Some(row) = rows.next()? {
-        let num: i64 = row.get(0)?;
-        let key: Option<String> = row.get(1)?;
-        let labels_json: String = row.get(6)?;
+        let labels_json: String = row.get(5)?;
         let labels = parse_labels_json(&labels_json);
-        let assignees_json: String = row.get::<_, Option<String>>(7)?.unwrap_or_default();
+        let assignees_json: String = row.get::<_, Option<String>>(6)?.unwrap_or_default();
         let assignees: Vec<String> = serde_json::from_str(&assignees_json).unwrap_or_default();
-        let priority: i64 = row.get::<_, Option<i64>>(8)?.unwrap_or(4);
+        let priority: i64 = row.get::<_, Option<i64>>(7)?.unwrap_or(4);
 
         Ok(Some(Issue {
-            number: num as u64,
-            key,
-            title: row.get(2)?,
-            body: row.get(3)?,
-            state: row.get(4)?,
-            author: row.get(5)?,
+            id: row.get(0)?,
+            title: row.get(1)?,
+            body: row.get(2)?,
+            state: row.get(3)?,
+            author: row.get(4)?,
             labels,
             assignees,
             priority: priority as u8,
-            priority_label: row.get(9)?,
-            created_at: row.get(10)?,
-            updated_at: row.get(11)?,
-            url: row.get(12)?,
-            milestone: row.get(13)?,
+            priority_label: row.get(8)?,
+            created_at: row.get(9)?,
+            updated_at: row.get(10)?,
+            url: row.get(11)?,
+            milestone: row.get(12)?,
         }))
     } else {
         Ok(None)
@@ -367,10 +370,9 @@ mod tests {
         conn
     }
 
-    fn make_issue(number: u64, title: &str, state: &str, labels: Vec<&str>) -> Issue {
+    fn make_issue(id: &str, title: &str, state: &str, labels: Vec<&str>) -> Issue {
         Issue {
-            number,
-            key: None,
+            id: id.to_string(),
             title: title.to_string(),
             body: None,
             state: state.to_string(),
@@ -427,17 +429,14 @@ mod tests {
         let conn = test_db();
 
         let issues = vec![
-            make_issue(1, "First", "open", vec![]),
-            make_issue(2, "Second", "open", vec!["bug"]),
+            make_issue("1", "First", "open", vec![]),
+            make_issue("2", "Second", "open", vec!["bug"]),
         ];
 
         save_issues(&conn, "owner/repo", &issues, true, true).unwrap();
 
         let loaded = load_issues(&conn, "owner/repo").unwrap();
         assert_eq!(loaded.len(), 2);
-        // Ordered by number DESC
-        assert_eq!(loaded[0].number, 2);
-        assert_eq!(loaded[1].number, 1);
     }
 
     #[test]
@@ -447,7 +446,7 @@ mod tests {
         save_issues(
             &conn,
             "owner/repo",
-            &[make_issue(1, "Old", "open", vec![])],
+            &[make_issue("1", "Old", "open", vec![])],
             true,
             true,
         )
@@ -455,7 +454,7 @@ mod tests {
         save_issues(
             &conn,
             "owner/repo",
-            &[make_issue(2, "New", "open", vec![])],
+            &[make_issue("2", "New", "open", vec![])],
             true,
             true,
         )
@@ -471,8 +470,8 @@ mod tests {
         let conn = test_db();
 
         let issues = vec![
-            make_issue(1, "Open issue", "open", vec![]),
-            make_issue(2, "Closed issue", "closed", vec![]),
+            make_issue("1", "Open issue", "open", vec![]),
+            make_issue("2", "Closed issue", "closed", vec![]),
         ];
         save_issues(&conn, "owner/repo", &issues, true, true).unwrap();
 
@@ -512,9 +511,9 @@ mod tests {
         let conn = test_db();
 
         let issues = vec![
-            make_issue(1, "Bug", "open", vec!["bug"]),
-            make_issue(2, "Feature", "open", vec!["enhancement"]),
-            make_issue(3, "Bug and feature", "open", vec!["bug", "enhancement"]),
+            make_issue("1", "Bug", "open", vec!["bug"]),
+            make_issue("2", "Feature", "open", vec!["enhancement"]),
+            make_issue("3", "Bug and feature", "open", vec!["bug", "enhancement"]),
         ];
         save_issues(&conn, "owner/repo", &issues, true, true).unwrap();
 
@@ -554,28 +553,28 @@ mod tests {
         save_issues(
             &conn,
             "owner/repo",
-            &[make_issue(42, "The answer", "open", vec![])],
+            &[make_issue("42", "The answer", "open", vec![])],
             true,
             true,
         )
         .unwrap();
 
-        let issue = load_issue(&conn, "owner/repo", 42).unwrap();
+        let issue = load_issue(&conn, "owner/repo", "42").unwrap();
         assert!(issue.is_some());
         assert_eq!(issue.unwrap().title, "The answer");
 
-        let missing = load_issue(&conn, "owner/repo", 999).unwrap();
+        let missing = load_issue(&conn, "owner/repo", "999").unwrap();
         assert!(missing.is_none());
     }
 
     #[test]
     fn test_filter_by_assignee() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "Assigned to alice", "open", vec![]);
+        let mut issue1 = make_issue("1", "Assigned to alice", "open", vec![]);
         issue1.assignees = vec!["alice".to_string()];
-        let mut issue2 = make_issue(2, "Assigned to bob", "open", vec![]);
+        let mut issue2 = make_issue("2", "Assigned to bob", "open", vec![]);
         issue2.assignees = vec!["bob".to_string()];
-        let issue3 = make_issue(3, "Unassigned", "open", vec![]);
+        let issue3 = make_issue("3", "Unassigned", "open", vec![]);
 
         save_issues(&conn, "owner/repo", &[issue1, issue2, issue3], true, true).unwrap();
 
@@ -592,15 +591,15 @@ mod tests {
         )
         .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].number, 1);
+        assert_eq!(results[0].id, "1");
     }
 
     #[test]
     fn test_filter_unassigned() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "Assigned", "open", vec![]);
+        let mut issue1 = make_issue("1", "Assigned", "open", vec![]);
         issue1.assignees = vec!["alice".to_string()];
-        let issue2 = make_issue(2, "Unassigned", "open", vec![]);
+        let issue2 = make_issue("2", "Unassigned", "open", vec![]);
 
         save_issues(&conn, "owner/repo", &[issue1, issue2], true, true).unwrap();
 
@@ -617,17 +616,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].number, 2);
+        assert_eq!(results[0].id, "2");
     }
 
     #[test]
     fn test_filter_by_goal() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "In v1.0", "open", vec![]);
+        let mut issue1 = make_issue("1", "In v1.0", "open", vec![]);
         issue1.milestone = Some("v1.0".to_string());
-        let mut issue2 = make_issue(2, "In v2.0", "open", vec![]);
+        let mut issue2 = make_issue("2", "In v2.0", "open", vec![]);
         issue2.milestone = Some("v2.0".to_string());
-        let issue3 = make_issue(3, "No milestone", "open", vec![]);
+        let issue3 = make_issue("3", "No milestone", "open", vec![]);
 
         save_issues(&conn, "owner/repo", &[issue1, issue2, issue3], true, true).unwrap();
 
@@ -644,17 +643,17 @@ mod tests {
         )
         .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].number, 1);
+        assert_eq!(results[0].id, "1");
     }
 
     #[test]
     fn test_sort_by_priority() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "Low priority", "open", vec![]);
+        let mut issue1 = make_issue("1", "Low priority", "open", vec![]);
         issue1.priority = 3;
-        let mut issue2 = make_issue(2, "High priority", "open", vec![]);
+        let mut issue2 = make_issue("2", "High priority", "open", vec![]);
         issue2.priority = 1;
-        let mut issue3 = make_issue(3, "Urgent", "open", vec![]);
+        let mut issue3 = make_issue("3", "Urgent", "open", vec![]);
         issue3.priority = 0;
 
         save_issues(&conn, "owner/repo", &[issue1, issue2, issue3], true, true).unwrap();
@@ -681,18 +680,13 @@ mod tests {
     #[test]
     fn test_sort_by_newest() {
         let conn = test_db();
-        save_issues(
-            &conn,
-            "owner/repo",
-            &[
-                make_issue(1, "Oldest", "open", vec![]),
-                make_issue(2, "Middle", "open", vec![]),
-                make_issue(3, "Newest", "open", vec![]),
-            ],
-            true,
-            true,
-        )
-        .unwrap();
+        let mut i1 = make_issue("1", "Oldest", "open", vec![]);
+        i1.created_at = "2024-01-01T00:00:00Z".to_string();
+        let mut i2 = make_issue("2", "Middle", "open", vec![]);
+        i2.created_at = "2024-01-02T00:00:00Z".to_string();
+        let mut i3 = make_issue("3", "Newest", "open", vec![]);
+        i3.created_at = "2024-01-03T00:00:00Z".to_string();
+        save_issues(&conn, "owner/repo", &[i1, i2, i3], true, true).unwrap();
 
         let results = load_issues_filtered(
             &conn,
@@ -706,26 +700,21 @@ mod tests {
             "newest",
         )
         .unwrap();
-        assert_eq!(results[0].number, 3);
-        assert_eq!(results[1].number, 2);
-        assert_eq!(results[2].number, 1);
+        assert_eq!(results[0].id, "3");
+        assert_eq!(results[1].id, "2");
+        assert_eq!(results[2].id, "1");
     }
 
     #[test]
     fn test_sort_by_oldest() {
         let conn = test_db();
-        save_issues(
-            &conn,
-            "owner/repo",
-            &[
-                make_issue(1, "Oldest", "open", vec![]),
-                make_issue(2, "Middle", "open", vec![]),
-                make_issue(3, "Newest", "open", vec![]),
-            ],
-            true,
-            true,
-        )
-        .unwrap();
+        let mut i1 = make_issue("1", "Oldest", "open", vec![]);
+        i1.created_at = "2024-01-01T00:00:00Z".to_string();
+        let mut i2 = make_issue("2", "Middle", "open", vec![]);
+        i2.created_at = "2024-01-02T00:00:00Z".to_string();
+        let mut i3 = make_issue("3", "Newest", "open", vec![]);
+        i3.created_at = "2024-01-03T00:00:00Z".to_string();
+        save_issues(&conn, "owner/repo", &[i1, i2, i3], true, true).unwrap();
 
         let results = load_issues_filtered(
             &conn,
@@ -739,19 +728,19 @@ mod tests {
             "oldest",
         )
         .unwrap();
-        assert_eq!(results[0].number, 1);
-        assert_eq!(results[1].number, 2);
-        assert_eq!(results[2].number, 3);
+        assert_eq!(results[0].id, "1");
+        assert_eq!(results[1].id, "2");
+        assert_eq!(results[2].id, "3");
     }
 
     #[test]
     fn test_sort_by_updated() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "Updated last", "open", vec![]);
+        let mut issue1 = make_issue("1", "Updated last", "open", vec![]);
         issue1.updated_at = "2024-01-03T00:00:00Z".to_string();
-        let mut issue2 = make_issue(2, "Updated first", "open", vec![]);
+        let mut issue2 = make_issue("2", "Updated first", "open", vec![]);
         issue2.updated_at = "2024-01-01T00:00:00Z".to_string();
-        let mut issue3 = make_issue(3, "Updated middle", "open", vec![]);
+        let mut issue3 = make_issue("3", "Updated middle", "open", vec![]);
         issue3.updated_at = "2024-01-02T00:00:00Z".to_string();
 
         save_issues(&conn, "owner/repo", &[issue1, issue2, issue3], true, true).unwrap();
@@ -769,23 +758,23 @@ mod tests {
         )
         .unwrap();
         // DESC by updated_at
-        assert_eq!(results[0].number, 1); // 2024-01-03
-        assert_eq!(results[1].number, 3); // 2024-01-02
-        assert_eq!(results[2].number, 2); // 2024-01-01
+        assert_eq!(results[0].id, "1"); // 2024-01-03
+        assert_eq!(results[1].id, "3"); // 2024-01-02
+        assert_eq!(results[2].id, "2"); // 2024-01-01
     }
 
     #[test]
     fn test_combined_filters() {
         let conn = test_db();
-        let mut issue1 = make_issue(1, "Match all", "open", vec!["bug"]);
+        let mut issue1 = make_issue("1", "Match all", "open", vec!["bug"]);
         issue1.assignees = vec!["alice".to_string()];
         issue1.milestone = Some("v1.0".to_string());
 
-        let mut issue2 = make_issue(2, "Wrong state", "closed", vec!["bug"]);
+        let mut issue2 = make_issue("2", "Wrong state", "closed", vec!["bug"]);
         issue2.assignees = vec!["alice".to_string()];
         issue2.milestone = Some("v1.0".to_string());
 
-        let mut issue3 = make_issue(3, "Wrong assignee", "open", vec!["bug"]);
+        let mut issue3 = make_issue("3", "Wrong assignee", "open", vec!["bug"]);
         issue3.assignees = vec!["bob".to_string()];
         issue3.milestone = Some("v1.0".to_string());
 
@@ -804,6 +793,6 @@ mod tests {
         )
         .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].number, 1);
+        assert_eq!(results[0].id, "1");
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -25,7 +25,7 @@ pub use goals::{count_goals, load_goal_by_name, load_goals, save_goal, save_goal
 
 // From issues
 pub use issues::{load_issue, load_issues_filtered, save_issues};
-#[cfg(test)]
+#[allow(unused_imports)]
 pub use issues::load_issues;
 
 // From rate_limit
@@ -96,10 +96,9 @@ mod tests {
         conn
     }
 
-    fn make_issue(number: u64, title: &str, state: &str, labels: Vec<&str>) -> Issue {
+    fn make_issue(id: &str, title: &str, state: &str, labels: Vec<&str>) -> Issue {
         Issue {
-            number,
-            key: None,
+            id: id.to_string(),
             title: title.to_string(),
             body: None,
             state: state.to_string(),
@@ -161,7 +160,7 @@ mod tests {
         save_issues(
             &conn,
             "owner/repo",
-            &[make_issue(1, "Test", "open", vec![])],
+            &[make_issue("1", "Test", "open", vec![])],
             true,
             true,
         )

--- a/src/db/repos.rs
+++ b/src/db/repos.rs
@@ -157,7 +157,7 @@ pub fn set_worktree_issue(
     conn: &Connection,
     git_dir: &str,
     repo: &str,
-    issue_number: i64,
+    issue_id: &str,
 ) -> Result<()> {
     // Clear any existing associations for this worktree (v1: one issue per worktree)
     conn.execute(
@@ -165,11 +165,19 @@ pub fn set_worktree_issue(
         params![git_dir],
     )?;
 
+    // Extract numeric part from issue ID for backward compatibility with 'issue_number' column
+    // For "123" → 123, for "DEV-123" → 123
+    let issue_number: i64 = issue_id
+        .split('-')
+        .last()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+
     // Insert the new association
     conn.execute(
-        "INSERT INTO worktree_issues (git_dir, repo, issue_number, created_at)
-         VALUES (?, ?, ?, datetime('now'))",
-        params![git_dir, repo, issue_number],
+        "INSERT INTO worktree_issues (git_dir, repo, issue_number, issue_id, created_at)
+         VALUES (?, ?, ?, ?, datetime('now'))",
+        params![git_dir, repo, issue_number, issue_id],
     )?;
 
     Ok(())
@@ -177,17 +185,17 @@ pub fn set_worktree_issue(
 
 /// Get the current issue for a worktree
 ///
-/// Returns (repo, issue_number) if an association exists.
-pub fn get_worktree_issue(conn: &Connection, git_dir: &str) -> Result<Option<(String, i64)>> {
+/// Returns (repo, issue_id) if an association exists.
+pub fn get_worktree_issue(conn: &Connection, git_dir: &str) -> Result<Option<(String, String)>> {
     let mut stmt = conn.prepare(
-        "SELECT repo, issue_number FROM worktree_issues WHERE git_dir = ? LIMIT 1",
+        "SELECT repo, issue_id FROM worktree_issues WHERE git_dir = ? LIMIT 1",
     )?;
 
     let result = stmt
         .query_row(params![git_dir], |row| {
             let repo: String = row.get(0)?;
-            let issue_number: i64 = row.get(1)?;
-            Ok((repo, issue_number))
+            let issue_id: String = row.get(1)?;
+            Ok((repo, issue_id))
         })
         .optional()?;
 
@@ -430,14 +438,14 @@ mod tests {
         assert!(result.is_none());
 
         // Set an issue
-        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", 123).unwrap();
+        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "123").unwrap();
 
         // Get the issue back
         let result = get_worktree_issue(&conn, "/path/to/.git").unwrap();
         assert!(result.is_some());
-        let (repo, issue_number) = result.unwrap();
+        let (repo, issue_id) = result.unwrap();
         assert_eq!(repo, "owner/repo");
-        assert_eq!(issue_number, 123);
+        assert_eq!(issue_id, "123");
     }
 
     #[test]
@@ -445,14 +453,14 @@ mod tests {
         let conn = test_db();
 
         // Set first issue
-        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", 100).unwrap();
+        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "100").unwrap();
 
         // Set a different issue (should replace)
-        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", 200).unwrap();
+        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "200").unwrap();
 
         // Should get the new issue
         let result = get_worktree_issue(&conn, "/path/to/.git").unwrap().unwrap();
-        assert_eq!(result.1, 200);
+        assert_eq!(result.1, "200");
     }
 
     #[test]
@@ -460,7 +468,7 @@ mod tests {
         let conn = test_db();
 
         // Set an issue
-        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", 123).unwrap();
+        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "123").unwrap();
 
         // Verify it exists
         assert!(get_worktree_issue(&conn, "/path/to/.git").unwrap().is_some());
@@ -477,12 +485,12 @@ mod tests {
         let conn = test_db();
 
         // Set issues for different worktrees
-        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", 100).unwrap();
+        set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "100").unwrap();
         set_worktree_issue(
             &conn,
             "/path/to/.git/worktrees/feature",
             "owner/repo",
-            200,
+            "DEV-200",
         )
         .unwrap();
 
@@ -492,7 +500,7 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(main.1, 100);
-        assert_eq!(feature.1, 200);
+        assert_eq!(main.1, "100");
+        assert_eq!(feature.1, "DEV-200");
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -317,10 +317,55 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute("ALTER TABLE issues ADD COLUMN deleted_at TEXT", [])?;
     }
 
-    // Migration: add key column to issues if it doesn't exist (for JIRA keys like PROJ-123)
-    let has_key: bool = conn.prepare("SELECT key FROM issues LIMIT 0").is_ok();
-    if !has_key {
-        conn.execute("ALTER TABLE issues ADD COLUMN key TEXT", [])?;
+    // Migration: add issue_id column to issues if it doesn't exist
+    // This replaces number with a string ID
+    let has_issue_id: bool = conn.prepare("SELECT issue_id FROM issues LIMIT 0").is_ok();
+    if !has_issue_id {
+        // Add the new column
+        conn.execute("ALTER TABLE issues ADD COLUMN issue_id TEXT", [])?;
+        // Migrate existing data: convert number to string
+        conn.execute(
+            "UPDATE issues SET issue_id = CAST(number AS TEXT) WHERE issue_id IS NULL",
+            [],
+        )?;
+    }
+
+    // Create unique index for issue_id (needed for ON CONFLICT clause)
+    // Use IF NOT EXISTS so this is idempotent
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_issues_repo_issue_id ON issues(repo, issue_id)",
+        [],
+    )?;
+
+    // Migration: add issue_id column to comments if it doesn't exist
+    let has_comments_issue_id: bool = conn
+        .prepare("SELECT issue_id FROM comments LIMIT 0")
+        .is_ok();
+    if !has_comments_issue_id {
+        conn.execute("ALTER TABLE comments ADD COLUMN issue_id TEXT", [])?;
+        // Migrate existing data: convert issue_number to string
+        conn.execute(
+            "UPDATE comments SET issue_id = CAST(issue_number AS TEXT) WHERE issue_id IS NULL",
+            [],
+        )?;
+        // Create new index
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_comments_issue_id ON comments(forge_repo, issue_id)",
+            [],
+        )?;
+    }
+
+    // Migration: add issue_id column to worktree_issues if it doesn't exist
+    let has_worktree_issue_id: bool = conn
+        .prepare("SELECT issue_id FROM worktree_issues LIMIT 0")
+        .is_ok();
+    if !has_worktree_issue_id {
+        conn.execute("ALTER TABLE worktree_issues ADD COLUMN issue_id TEXT", [])?;
+        // Migrate existing data: convert issue_number to string
+        conn.execute(
+            "UPDATE worktree_issues SET issue_id = CAST(issue_number AS TEXT) WHERE issue_id IS NULL",
+            [],
+        )?;
     }
 
     // Migration: add updated_at and soft-delete columns to comments

--- a/src/display.rs
+++ b/src/display.rs
@@ -66,6 +66,17 @@ fn compact_date(timestamp: &str) -> String {
     }
 }
 
+/// Format an issue ID for display
+/// Returns "#123" for numeric IDs (GitHub), or the ID as-is for string IDs (Linear/JIRA)
+pub fn format_issue_id(id: &str) -> String {
+    // If the ID is purely numeric, prefix with #
+    if id.chars().all(|c| c.is_ascii_digit()) {
+        format!("#{}", id)
+    } else {
+        id.to_string()
+    }
+}
+
 /// Check if stdout is a terminal (for color support)
 fn is_tty() -> bool {
     std::io::stdout().is_terminal()
@@ -177,8 +188,9 @@ fn wrap_indented(text: &str, indent: &str, width: usize) -> String {
 pub fn print_issue(issue: &Issue, comments: &[Comment], elapsed_ms: u64) {
     let tty = is_tty();
 
-    // Title line
-    let title_line = format!("  #{} {}", issue.number, issue.title);
+    // Title line - format ID: "#123" for GitHub, "DEV-123" for Linear/JIRA
+    let issue_id_display = format_issue_id(&issue.id);
+    let title_line = format!("  {} {}", issue_id_display, issue.title);
     if tty {
         println!("{}", title_line.bold());
     } else {
@@ -362,12 +374,8 @@ pub fn print_issue_row(issue: &Issue, comment_count: Option<usize>) {
     // Format created date
     let date_str = compact_date(&issue.created_at);
 
-    // Use key (e.g., "PROJ-123") if available, otherwise "#number"
-    let issue_id = issue
-        .key
-        .as_ref()
-        .cloned()
-        .unwrap_or_else(|| format!("#{}", issue.number));
+    // Format issue ID: "#123" for GitHub, "DEV-123" for Linear/JIRA
+    let issue_id = format_issue_id(&issue.id);
 
     if tty {
         println!(

--- a/src/forges/github/mod.rs
+++ b/src/forges/github/mod.rs
@@ -209,29 +209,41 @@ impl Forge for GitHubClient {
         self.create_issue(repo, &req).await
     }
 
-    async fn create_comment(&self, repo: &Repo, issue_number: u64, body: &str) -> Result<()> {
+    async fn create_comment(&self, repo: &Repo, issue_id: &str, body: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.create_comment(repo, issue_number, body).await
     }
 
-    async fn close_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
+    async fn close_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.patch_issue(repo, issue_number, &serde_json::json!({ "state": "closed" }))
             .await
     }
 
-    async fn reopen_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
+    async fn reopen_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.patch_issue(repo, issue_number, &serde_json::json!({ "state": "open" }))
             .await
     }
 
-    async fn add_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
+    async fn add_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.add_label(repo, issue_number, label).await
     }
 
-    async fn remove_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
+    async fn remove_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.remove_label(repo, issue_number, label).await
     }
 
-    async fn assign_issue(&self, repo: &Repo, issue_number: u64, assignee: &str) -> Result<()> {
+    async fn assign_issue(&self, repo: &Repo, issue_id: &str, assignee: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.assign_issue(repo, issue_number, assignee).await
     }
 
@@ -245,7 +257,7 @@ impl Forge for GitHubClient {
             .filter_map(|c| {
                 Some(crate::db::Comment {
                     comment_id: c.id.to_string(),
-                    issue_number: c.issue_number()?,
+                    issue_id: c.issue_id()?,
                     body: c.body,
                     author: c.user.login,
                     created_at: c.created_at,
@@ -274,7 +286,7 @@ impl Forge for GitHubClient {
             .filter_map(|c| {
                 Some(crate::db::Comment {
                     comment_id: c.id.to_string(),
-                    issue_number: c.issue_number()?,
+                    issue_id: c.issue_id()?,
                     body: c.body,
                     author: c.user.login,
                     created_at: c.created_at,
@@ -306,7 +318,9 @@ impl Forge for GitHubClient {
         self.close_milestone(repo, number).await
     }
 
-    async fn assign_to_goal(&self, repo: &Repo, issue_number: u64, goal_id: &str) -> Result<()> {
+    async fn assign_to_goal(&self, repo: &Repo, issue_id: &str, goal_id: &str) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         let milestone_number: u64 = goal_id
             .parse()
             .map_err(|_| anyhow::anyhow!("Invalid milestone number: {}", goal_id))?;
@@ -321,10 +335,13 @@ impl Forge for GitHubClient {
     async fn handle_on_start(
         &self,
         repo: &Repo,
-        issue_number: u64,
+        issue_id: &str,
         config: &toml::Value,
         username: Option<&str>,
     ) -> Result<()> {
+        let issue_number: u64 = issue_id.parse()
+            .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
+
         // Parse GitHub-specific config from opaque toml::Value
         let cfg: GitHubOnStartConfig = config.clone().try_into().unwrap_or_default();
 
@@ -374,11 +391,10 @@ impl Forge for GitHubClient {
 mod tests {
     use super::*;
 
-    fn make_issue(number: u64, labels: Vec<&str>) -> Issue {
+    fn make_issue(id: &str, labels: Vec<&str>) -> Issue {
         Issue {
-            number,
-            key: None,
-            title: format!("Issue {}", number),
+            id: id.to_string(),
+            title: format!("Issue {}", id),
             body: None,
             state: "open".to_string(),
             author: "testuser".to_string(),
@@ -407,7 +423,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut issues = vec![make_issue(1, vec!["P0", "bug"])];
+        let mut issues = vec![make_issue("1", vec!["P0", "bug"])];
         apply_priority_from_labels(&mut issues, &config);
 
         assert_eq!(issues[0].priority, 0);
@@ -425,7 +441,7 @@ mod tests {
         .unwrap();
 
         // Issue has both P1 (priority 1) and P0 (priority 0) - should pick P0
-        let mut issues = vec![make_issue(1, vec!["P1", "P0"])];
+        let mut issues = vec![make_issue("1", vec!["P1", "P0"])];
         apply_priority_from_labels(&mut issues, &config);
 
         assert_eq!(issues[0].priority, 0);
@@ -442,7 +458,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut issues = vec![make_issue(1, vec!["bug", "enhancement"])];
+        let mut issues = vec![make_issue("1", vec!["bug", "enhancement"])];
         apply_priority_from_labels(&mut issues, &config);
 
         // Should remain at default priority
@@ -454,7 +470,7 @@ mod tests {
     fn test_priority_empty_config() {
         let config: toml::Value = toml::from_str("").unwrap();
 
-        let mut issues = vec![make_issue(1, vec!["P0"])];
+        let mut issues = vec![make_issue("1", vec!["P0"])];
         apply_priority_from_labels(&mut issues, &config);
 
         // No config means no priority mapping
@@ -473,7 +489,7 @@ mod tests {
         .unwrap();
 
         // P0 should work, but bad/negative should be ignored
-        let mut issues = vec![make_issue(1, vec!["P0"]), make_issue(2, vec!["bad"])];
+        let mut issues = vec![make_issue("1", vec!["P0"]), make_issue("2", vec!["bad"])];
         apply_priority_from_labels(&mut issues, &config);
 
         assert_eq!(issues[0].priority, 0); // P0 works

--- a/src/forges/github/types.rs
+++ b/src/forges/github/types.rs
@@ -27,8 +27,7 @@ pub struct GitHubIssue {
 impl GitHubIssue {
     pub fn into_issue(self) -> Issue {
         Issue {
-            number: self.number,
-            key: None,
+            id: self.number.to_string(),
             title: self.title,
             body: self.body,
             state: self.state,
@@ -78,9 +77,9 @@ pub struct GitHubComment {
 }
 
 impl GitHubComment {
-    /// Parse issue number from issue_url (e.g., "https://api.github.com/repos/owner/repo/issues/123")
-    pub fn issue_number(&self) -> Option<u64> {
-        self.issue_url.rsplit('/').next()?.parse().ok()
+    /// Parse issue ID from issue_url (e.g., "https://api.github.com/repos/owner/repo/issues/123")
+    pub fn issue_id(&self) -> Option<String> {
+        self.issue_url.rsplit('/').next().map(|s| s.to_string())
     }
 }
 

--- a/src/forges/jira/client.rs
+++ b/src/forges/jira/client.rs
@@ -290,17 +290,6 @@ impl JiraClient {
         }
     }
 
-    /// Parse issue number from either full key (PROJ-123) or just number (123)
-    pub fn parse_issue_key(&self, repo: &Repo, issue_ref: &str) -> String {
-        if issue_ref.contains('-') {
-            // Already a full key
-            issue_ref.to_string()
-        } else {
-            // Just a number - prepend project key (repo.name is the project key)
-            format!("{}-{}", repo.name, issue_ref)
-        }
-    }
-
     /// List available JIRA fields (for JQL queries)
     pub async fn list_fields(&self) -> Result<()> {
         #[derive(Debug, Deserialize)]
@@ -408,17 +397,8 @@ impl JiraClient {
             .and_then(|v| v.first())
             .map(|v| v.name.clone());
 
-        // Extract issue number from key (e.g., "PROJ-123" -> 123)
-        let number: u64 = jira_issue
-            .key
-            .split('-')
-            .last()
-            .and_then(|n| n.parse().ok())
-            .unwrap_or(0);
-
         Issue {
-            number,
-            key: Some(jira_issue.key.clone()),
+            id: jira_issue.key.clone(),
             title: jira_issue.fields.summary.clone(),
             body,
             state: state.to_string(),
@@ -516,13 +496,6 @@ impl JiraClient {
 
             // For each issue, fetch comments
             for jira_issue in &response.issues {
-                let issue_number: u64 = jira_issue
-                    .key
-                    .split('-')
-                    .last()
-                    .and_then(|n| n.parse().ok())
-                    .unwrap_or(0);
-
                 // Paginate through all comments for this issue
                 let mut start_at: u64 = 0;
                 loop {
@@ -545,7 +518,7 @@ impl JiraClient {
 
                         all_comments.push(db::Comment {
                             comment_id: comment.id.clone(),
-                            issue_number,
+                            issue_id: jira_issue.key.clone(),
                             body,
                             author: comment
                                 .author

--- a/src/forges/jira/mod.rs
+++ b/src/forges/jira/mod.rs
@@ -380,9 +380,8 @@ impl Forge for JiraClient {
         self.create_issue(repo, &req.title, req.body.as_deref(), &req.labels, issue_type).await
     }
 
-    async fn create_comment(&self, repo: &Repo, issue_number: u64, body: &str) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-        let path = format!("/issue/{}/comment", issue_key);
+    async fn create_comment(&self, _repo: &Repo, issue_id: &str, body: &str) -> Result<()> {
+        let path = format!("/issue/{}/comment", issue_id);
 
         let comment_body = serde_json::json!({
             "body": adf::markdown_to_adf(body)
@@ -391,11 +390,9 @@ impl Forge for JiraClient {
         self.post_no_response(&path, &comment_body).await
     }
 
-    async fn close_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-
+    async fn close_issue(&self, _repo: &Repo, issue_id: &str) -> Result<()> {
         // Get available transitions
-        let path = format!("/issue/{}/transitions", issue_key);
+        let path = format!("/issue/{}/transitions", issue_id);
         let response: types::JiraTransitionsResponse = self.get(&path).await?;
 
         // Find a "Done" transition
@@ -415,11 +412,9 @@ impl Forge for JiraClient {
         self.post_no_response(&path, &body).await
     }
 
-    async fn reopen_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-
+    async fn reopen_issue(&self, _repo: &Repo, issue_id: &str) -> Result<()> {
         // Get available transitions
-        let path = format!("/issue/{}/transitions", issue_key);
+        let path = format!("/issue/{}/transitions", issue_id);
         let response: types::JiraTransitionsResponse = self.get(&path).await?;
 
         // Find a "To Do" or "Reopen" transition
@@ -441,9 +436,8 @@ impl Forge for JiraClient {
         self.post_no_response(&path, &body).await
     }
 
-    async fn add_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-        let path = format!("/issue/{}", issue_key);
+    async fn add_label(&self, _repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let path = format!("/issue/{}", issue_id);
 
         let body = serde_json::json!({
             "update": {
@@ -454,9 +448,8 @@ impl Forge for JiraClient {
         self.put(&path, &body).await
     }
 
-    async fn remove_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-        let path = format!("/issue/{}", issue_key);
+    async fn remove_label(&self, _repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let path = format!("/issue/{}", issue_id);
 
         let body = serde_json::json!({
             "update": {
@@ -467,9 +460,8 @@ impl Forge for JiraClient {
         self.put(&path, &body).await
     }
 
-    async fn assign_issue(&self, repo: &Repo, issue_number: u64, assignee: &str) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-        let path = format!("/issue/{}/assignee", issue_key);
+    async fn assign_issue(&self, _repo: &Repo, issue_id: &str, assignee: &str) -> Result<()> {
+        let path = format!("/issue/{}/assignee", issue_id);
 
         // Handle unassign case
         let body = if assignee.is_empty() || assignee == "null" {
@@ -535,9 +527,8 @@ impl Forge for JiraClient {
         self.put(&path, &body).await
     }
 
-    async fn assign_to_goal(&self, repo: &Repo, issue_number: u64, goal_id: &str) -> Result<()> {
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
-        let path = format!("/issue/{}", issue_key);
+    async fn assign_to_goal(&self, _repo: &Repo, issue_id: &str, goal_id: &str) -> Result<()> {
+        let path = format!("/issue/{}", issue_id);
 
         // Get version name from ID
         let version_path = format!("/version/{}", goal_id);
@@ -576,16 +567,15 @@ impl Forge for JiraClient {
     async fn handle_on_start(
         &self,
         repo: &Repo,
-        issue_number: u64,
+        issue_id: &str,
         config: &toml::Value,
         username: Option<&str>,
     ) -> Result<()> {
         let on_start: JiraOnStartConfig = config.clone().try_into()?;
-        let issue_key = self.parse_issue_key(repo, &issue_number.to_string());
 
         // Handle transition
         if let Some(transition_name) = &on_start.transition {
-            let path = format!("/issue/{}/transitions", issue_key);
+            let path = format!("/issue/{}/transitions", issue_id);
             let response: types::JiraTransitionsResponse = self.get(&path).await?;
 
             let transition = response
@@ -611,7 +601,7 @@ impl Forge for JiraClient {
         // Handle assign_self
         if on_start.assign_self {
             if let Some(account_id) = username {
-                self.assign_issue(repo, issue_number, account_id).await?;
+                Forge::assign_issue(self, repo, issue_id, account_id).await?;
             }
         }
 

--- a/src/forges/linear/client.rs
+++ b/src/forges/linear/client.rs
@@ -493,9 +493,8 @@ impl LinearClient {
             let url = format!("https://linear.app/{}/issue/{}", url_key, i.identifier);
             let priority = map_linear_priority(i.priority);
             Issue {
-                number: i.number,
-                key: None,
-                title: format!("{} {}", i.identifier, i.title),
+                id: i.identifier,
+                title: i.title,
                 body: i.description,
                 state: if i.state.state_type == "completed" || i.state.state_type == "canceled" {
                     "closed".to_string()
@@ -663,7 +662,7 @@ impl LinearClient {
                                 name
                             }
                             issue {
-                                number
+                                identifier
                             }
                             createdAt
                             updatedAt
@@ -690,7 +689,7 @@ impl LinearClient {
                                 name
                             }
                             issue {
-                                number
+                                identifier
                             }
                             createdAt
                             updatedAt
@@ -717,7 +716,7 @@ impl LinearClient {
                     for comment in response.comments.nodes {
                         all_comments.push(db::Comment {
                             comment_id: comment.id,
-                            issue_number: comment.issue.number,
+                            issue_id: comment.issue.identifier.clone(),
                             body: comment.body,
                             author: comment.user.map(|u| u.name).unwrap_or_else(|| "unknown".to_string()),
                             created_at: comment.created_at,

--- a/src/forges/linear/mod.rs
+++ b/src/forges/linear/mod.rs
@@ -100,6 +100,16 @@ pub(super) mod urlencoding {
     }
 }
 
+/// Parse a Linear issue identifier (e.g., "DEV-123") and extract the numeric part
+fn parse_issue_number(issue_id: &str) -> anyhow::Result<u64> {
+    // Linear identifiers are in the format "KEY-123"
+    issue_id
+        .rsplit('-')
+        .next()
+        .and_then(|n| n.parse().ok())
+        .ok_or_else(|| anyhow!("Invalid Linear issue identifier: {}", issue_id))
+}
+
 // ============================================================================
 // Link Flow
 // ============================================================================
@@ -290,9 +300,8 @@ impl Forge for LinearClient {
         let url = format!("https://linear.app/{}/issue/{}", org.url_key, created.identifier);
 
         Ok(Issue {
-            number: created.number,
-            key: None,
-            title: format!("{} {}", created.identifier, created.title),
+            id: created.identifier,
+            title: created.title,
             body: req.body,
             state: "open".to_string(),
             author: "me".to_string(),
@@ -307,7 +316,8 @@ impl Forge for LinearClient {
         })
     }
 
-    async fn create_comment(&self, repo: &Repo, issue_number: u64, body: &str) -> Result<()> {
+    async fn create_comment(&self, repo: &Repo, issue_id: &str, body: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
 
         let query = r#"
@@ -330,7 +340,8 @@ impl Forge for LinearClient {
         Ok(())
     }
 
-    async fn close_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
+    async fn close_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
         let done_state = self.get_state_by_type(&repo.name, "completed").await?;
 
@@ -354,7 +365,8 @@ impl Forge for LinearClient {
         Ok(())
     }
 
-    async fn reopen_issue(&self, repo: &Repo, issue_number: u64) -> Result<()> {
+    async fn reopen_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
         // Try "backlog" first, fall back to "unstarted" or "started"
         let backlog_state = match self.get_state_by_type(&repo.name, "backlog").await {
@@ -385,7 +397,8 @@ impl Forge for LinearClient {
         Ok(())
     }
 
-    async fn add_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
+    async fn add_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
         let label_ids = self.get_label_ids(&repo.name, &[label.to_string()]).await?;
 
@@ -419,7 +432,8 @@ impl Forge for LinearClient {
         Ok(())
     }
 
-    async fn remove_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()> {
+    async fn remove_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
 
         // Get current label IDs and remove the specified one
@@ -449,7 +463,8 @@ impl Forge for LinearClient {
         Ok(())
     }
 
-    async fn assign_issue(&self, repo: &Repo, issue_number: u64, assignee: &str) -> Result<()> {
+    async fn assign_issue(&self, repo: &Repo, issue_id: &str, assignee: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
         // CLI path: look up user by name/email to get their ID
         let user = self.get_user_by_name(assignee).await?;
         self.assign_issue_by_id(&repo.name, issue_number, &user.id).await
@@ -477,8 +492,9 @@ impl Forge for LinearClient {
         self.complete_project(goal_id).await
     }
 
-    async fn assign_to_goal(&self, repo: &Repo, issue_number: u64, goal_id: &str) -> Result<()> {
-        // Get the issue ID from the issue number
+    async fn assign_to_goal(&self, repo: &Repo, issue_id: &str, goal_id: &str) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
+        // Get the internal issue ID from the issue number
         let issue = self.get_issue_by_number(&repo.name, issue_number).await?;
         self.set_issue_project(&issue.id, goal_id).await
     }
@@ -528,7 +544,9 @@ impl Forge for LinearClient {
         }
     }
 
-    async fn handle_on_start(&self, repo: &Repo, issue_number: u64, config: &toml::Value, user_id: Option<&str>) -> Result<()> {
+    async fn handle_on_start(&self, repo: &Repo, issue_id: &str, config: &toml::Value, user_id: Option<&str>) -> Result<()> {
+        let issue_number = parse_issue_number(issue_id)?;
+
         // Parse Linear-specific config from opaque toml::Value
         let cfg: LinearOnStartConfig = config.clone().try_into().unwrap_or_default();
 

--- a/src/forges/linear/types.rs
+++ b/src/forges/linear/types.rs
@@ -132,7 +132,8 @@ pub struct PageInfo {
 #[derive(Deserialize)]
 pub struct LinearIssue {
     pub identifier: String,
-    pub number: u64,
+    #[allow(dead_code)]
+    pub number: u64, // From API but unused - we use identifier instead
     pub title: String,
     pub description: Option<String>,
     pub state: LinearState,
@@ -262,7 +263,7 @@ pub struct LinearCommentWithIssue {
 
 #[derive(Deserialize)]
 pub struct CommentIssueRef {
-    pub number: u64,
+    pub identifier: String,
 }
 
 #[derive(Deserialize)]
@@ -288,7 +289,8 @@ pub struct IssueCreatePayload {
 #[derive(Deserialize)]
 pub struct CreatedIssue {
     pub identifier: String,
-    pub number: u64,
+    #[allow(dead_code)]
+    pub number: u64, // From API but unused - we use identifier instead
     pub title: String,
 }
 

--- a/src/forges/mod.rs
+++ b/src/forges/mod.rs
@@ -226,10 +226,11 @@ impl Label {
 /// Forge-agnostic issue representation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Issue {
-    pub number: u64,
-    /// Full issue key for display (e.g., "PROJ-123" for JIRA, None for GitHub/Linear)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub key: Option<String>,
+    /// Unique issue identifier - format varies by forge:
+    /// - GitHub: "123" (issue number as string)
+    /// - Linear: "DEV-123" (identifier)
+    /// - JIRA: "PROJ-123" (key)
+    pub id: String,
     pub title: String,
     pub body: Option<String>,
     pub state: String,
@@ -472,22 +473,22 @@ pub trait Forge: Send + Sync {
     async fn create_issue(&self, repo: &Repo, req: CreateIssueRequest) -> Result<Issue>;
 
     /// Add a comment to an issue
-    async fn create_comment(&self, repo: &Repo, issue_number: u64, body: &str) -> Result<()>;
+    async fn create_comment(&self, repo: &Repo, issue_id: &str, body: &str) -> Result<()>;
 
     /// Close an issue
-    async fn close_issue(&self, repo: &Repo, issue_number: u64) -> Result<()>;
+    async fn close_issue(&self, repo: &Repo, issue_id: &str) -> Result<()>;
 
     /// Reopen an issue
-    async fn reopen_issue(&self, repo: &Repo, issue_number: u64) -> Result<()>;
+    async fn reopen_issue(&self, repo: &Repo, issue_id: &str) -> Result<()>;
 
     /// Add a label to an issue
-    async fn add_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()>;
+    async fn add_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()>;
 
     /// Remove a label from an issue
-    async fn remove_label(&self, repo: &Repo, issue_number: u64, label: &str) -> Result<()>;
+    async fn remove_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()>;
 
     /// Assign a user to an issue
-    async fn assign_issue(&self, repo: &Repo, issue_number: u64, assignee: &str) -> Result<()>;
+    async fn assign_issue(&self, repo: &Repo, issue_id: &str, assignee: &str) -> Result<()>;
 
     /// List all comments for a repo (full fetch)
     async fn list_all_comments(&self, repo: &Repo) -> Result<FetchResult<db::Comment>>;
@@ -505,7 +506,7 @@ pub trait Forge: Send + Sync {
     async fn close_goal(&self, repo: &Repo, goal_id: &str) -> Result<()>;
 
     /// Assign an issue to a goal
-    async fn assign_to_goal(&self, repo: &Repo, issue_number: u64, goal_id: &str) -> Result<()>;
+    async fn assign_to_goal(&self, repo: &Repo, issue_id: &str, goal_id: &str) -> Result<()>;
 
     /// Get rate limit status (returns None if forge doesn't have rate limits)
     async fn get_rate_limit(&self) -> Result<Option<RateLimitInfo>>;
@@ -519,7 +520,7 @@ pub trait Forge: Send + Sync {
     /// Handle on_start lifecycle event for an issue
     /// Each forge interprets the config according to its own schema
     /// username is provided for assign_self functionality
-    async fn handle_on_start(&self, repo: &Repo, issue_number: u64, config: &toml::Value, username: Option<&str>) -> Result<()>;
+    async fn handle_on_start(&self, repo: &Repo, issue_id: &str, config: &toml::Value, username: Option<&str>) -> Result<()>;
 
     /// Validate on_start config before use
     /// Returns error with helpful message if config is invalid

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
                 json,
             } => cli::goals::cmd_create(name, target, body, json).await?,
             GoalCommands::Assign { issue, goal, json } => {
-                cli::goals::cmd_assign(issue, goal, json).await?
+                cli::goals::cmd_assign(&issue, goal, json).await?
             }
             GoalCommands::Close { name, json } => cli::goals::cmd_close(name, json).await?,
         },

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -216,13 +216,13 @@ pub fn remove_worktree(worktree_path: &std::path::Path) -> Result<()> {
 ///
 /// Environment variables available to the script:
 /// - `ISQ_MAIN_WORKTREE`: Path to the main worktree
-/// - `ISQ_ISSUE_NUMBER`: The issue number being worked on
+/// - `ISQ_ISSUE_ID`: The issue ID being worked on (e.g., "123" or "DEV-123")
 /// - `ISQ_WORKTREE_PATH`: Path to the new worktree
 pub async fn run_setup_script(
     worktree_path: &std::path::Path,
     script: &str,
     main_worktree: &std::path::Path,
-    issue_number: u64,
+    issue_id: &str,
 ) -> Result<()> {
     use tokio::process::Command as TokioCommand;
 
@@ -231,7 +231,7 @@ pub async fn run_setup_script(
         .arg(script)
         .current_dir(worktree_path)
         .env("ISQ_MAIN_WORKTREE", main_worktree)
-        .env("ISQ_ISSUE_NUMBER", issue_number.to_string())
+        .env("ISQ_ISSUE_ID", issue_id)
         .env("ISQ_WORKTREE_PATH", worktree_path)
         .output()
         .await?;


### PR DESCRIPTION
Replace Issue.number (u64) and Issue.key (Option<String>) with a single
Issue.id (String) field that stores the native identifier for each forge:
- GitHub: "123" (issue number as string)
- Linear: "DEV-123" (identifier)
- JIRA: "PROJ-123" (key)

Update all Forge trait methods to accept issue_id: &str instead of
issue_number: u64. This simplifies the API and removes the need for
workarounds to extract/reconstruct numeric IDs from JIRA keys.

Database schema updated to use issue_id TEXT instead of number INTEGER.
Existing databases should be re-synced after this change.

Closes #74