### PR TITLE
Fix infinite sync retry loop when full sync fails

### DIFF
--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 use crate::db;
-use crate::forges::{get_forge_for_repo, CreateIssueRequest, Forge};
+use crate::forges::{get_forge_for_repo, CreateIssueRequest, FetchResult, Forge};
 use crate::repo::Repo;
 
 // Sync all repos at this interval
@@ -18,6 +18,7 @@ const SYNC_INTERVAL_SECS: u64 = 15; // Reduced from 30s since incremental is che
 const MAX_BACKOFF_SECS: u64 = 3600; // Max 1 hour backoff
 const FULL_SYNC_INTERVAL_HOURS: i64 = 1; // Hours between full reconciliation syncs
 const MAX_CONCURRENT_SYNCS: usize = 4; // Max repos to sync in parallel
+const FULL_SYNC_RETRY_COOLDOWN_MINS: i64 = 15; // Minutes to wait after failed full sync attempt
 
 /// Get the daemon PID file path
 pub fn pid_path() -> Result<PathBuf> {
@@ -219,20 +220,36 @@ pub async fn run_loop() -> Result<()> {
 }
 
 /// Determine if we need a full sync based on sync state
-fn should_do_full_sync(sync_state: &Option<db::SyncState>) -> bool {
-    match sync_state {
-        None => true, // First sync
-        Some(state) => {
-            let last_full = state.last_full_sync_at.as_ref()
-                .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
-                .map(|t| t.with_timezone(&Utc));
+/// Returns (should_do_full_sync, in_cooldown)
+fn should_do_full_sync(sync_state: &Option<db::SyncState>, has_cursor: bool) -> (bool, bool) {
+    let Some(state) = sync_state else {
+        return (true, false); // First sync ever
+    };
 
-            match last_full {
-                None => true, // Never done full sync
-                Some(ts) => Utc::now() - ts > ChronoDuration::hours(FULL_SYNC_INTERVAL_HOURS),
-            }
-        }
+    let now = Utc::now();
+
+    // Check if we're in cooldown from a recent attempt (prevents retry storms)
+    let in_cooldown = state.last_full_sync_attempt_at.as_ref()
+        .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
+        .map(|t| now - t.with_timezone(&Utc) <= ChronoDuration::minutes(FULL_SYNC_RETRY_COOLDOWN_MINS))
+        .unwrap_or(false);
+
+    if in_cooldown {
+        return (false, true);
     }
+
+    // Not in cooldown - check if we need full sync
+    if !has_cursor {
+        return (true, false); // No cursor available, must do full sync
+    }
+
+    // Check if successful full sync is stale (> 1 hour)
+    let needs_full = state.last_full_sync_at.as_ref()
+        .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
+        .map(|t| now - t.with_timezone(&Utc) > ChronoDuration::hours(FULL_SYNC_INTERVAL_HOURS))
+        .unwrap_or(true); // Never successfully completed
+
+    (needs_full, false)
 }
 
 /// Handle rate limit errors by recording state
@@ -243,7 +260,7 @@ async fn handle_rate_limit_error(
     e: &anyhow::Error,
 ) -> Result<()> {
     let err_str = e.to_string();
-    if err_str.contains("rate limit") || err_str.contains("403") {
+    if err_str.contains("rate limit") || err_str.contains("429") || err_str.contains("403") {
         if let Ok(Some(rate_info)) = forge.get_rate_limit().await {
             db::set_rate_limit_state(conn, forge_type, Some(rate_info.reset_at), Some(&err_str))?;
             eprintln!(
@@ -312,18 +329,27 @@ async fn sync_once(repo_path: &str) -> Result<()> {
         }
     }
 
-    // Determine if we need full sync based on sync state
-    let sync_state = db::get_sync_state(&conn, &link.forge_repo)?;
-    let needs_full_sync = should_do_full_sync(&sync_state);
-
     // === ISSUES ===
     // Calculate cursor for incremental sync (subtract 1 second for safety buffer)
+    let sync_state = db::get_sync_state(&conn, &link.forge_repo)?;
     let issues_cursor = sync_state.as_ref()
         .and_then(|s| s.issues_last_sync.as_ref())
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
         .map(|t| t.with_timezone(&Utc) - ChronoDuration::seconds(1));
 
-    let issues_result = if needs_full_sync || issues_cursor.is_none() {
+    // Determine if we need full sync based on sync state and cursor availability
+    let (needs_full_sync, in_cooldown) = should_do_full_sync(&sync_state, issues_cursor.is_some());
+
+    // If in cooldown with no cursor, skip this sync entirely
+    if in_cooldown && issues_cursor.is_none() {
+        eprintln!(
+            "[daemon] Skipping {} - full sync in cooldown, no cursor for incremental",
+            link.forge_repo
+        );
+        return Ok(());
+    }
+
+    let issues_result = if needs_full_sync {
         match forge.list_issues(&repo).await {
             Ok(result) => result,
             Err(e) => {
@@ -362,7 +388,11 @@ async fn sync_once(repo_path: &str) -> Result<()> {
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
         .map(|t| t.with_timezone(&Utc) - ChronoDuration::seconds(1));
 
-    let comments_result = if needs_full_sync || comments_cursor.is_none() {
+    // Determine comments sync strategy:
+    // - needs_full_sync: do full comments sync
+    // - has cursor: do incremental sync
+    // - in_cooldown with no cursor: skip comments (can't do anything safely)
+    let comments_result = if needs_full_sync {
         match forge.list_all_comments(&repo).await {
             Ok(result) => result,
             Err(e) => {
@@ -370,14 +400,17 @@ async fn sync_once(repo_path: &str) -> Result<()> {
                 return Err(e);
             }
         }
-    } else {
-        match forge.list_comments_since(&repo, comments_cursor.unwrap()).await {
+    } else if let Some(cursor) = comments_cursor {
+        match forge.list_comments_since(&repo, cursor).await {
             Ok(result) => result,
             Err(e) => {
                 handle_rate_limit_error(&conn, &link.forge_type, forge.as_ref(), &e).await?;
                 return Err(e);
             }
         }
+    } else {
+        // In cooldown with no cursor - skip comments sync
+        FetchResult::complete(vec![])
     };
 
     let comments_stats = db::save_comments(

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -169,21 +169,39 @@ pub fn save_issues(
 
     // Update sync state with server-derived cursor
     let now = chrono::Utc::now().to_rfc3339();
-    if full_sync && is_complete {
-        // Use server-derived timestamp (max_updated_at) for last_full_sync_at
-        // Fall back to client time if no issues were returned
-        let full_sync_cursor = max_updated_at.as_ref().unwrap_or(&now);
-        tx.execute(
-            "INSERT INTO sync_state (repo, last_sync, issue_count, issues_last_sync, last_full_sync_at)
-             VALUES (?1, ?2, ?3, ?4, ?5)
-             ON CONFLICT(repo) DO UPDATE SET
-                last_sync = ?2,
-                issue_count = ?3,
-                issues_last_sync = COALESCE(?4, issues_last_sync),
-                last_full_sync_at = ?5",
-            params![repo, now, issue_count, max_updated_at, full_sync_cursor],
-        )?;
+    if full_sync {
+        if is_complete {
+            // Full sync succeeded: update both last_full_sync_at and last_full_sync_attempt_at
+            let full_sync_cursor = max_updated_at.as_ref().unwrap_or(&now);
+            tx.execute(
+                "INSERT INTO sync_state (repo, last_sync, issue_count, issues_last_sync,
+                                         last_full_sync_at, last_full_sync_attempt_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(repo) DO UPDATE SET
+                    last_sync = ?2,
+                    issue_count = ?3,
+                    issues_last_sync = COALESCE(?4, issues_last_sync),
+                    last_full_sync_at = ?5,
+                    last_full_sync_attempt_at = ?6",
+                params![repo, now, issue_count, max_updated_at, full_sync_cursor, now],
+            )?;
+        } else {
+            // Full sync incomplete: only update last_full_sync_attempt_at (not last_full_sync_at)
+            // This allows cooldown to prevent retry storms
+            tx.execute(
+                "INSERT INTO sync_state (repo, last_sync, issue_count, issues_last_sync,
+                                         last_full_sync_attempt_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5)
+                 ON CONFLICT(repo) DO UPDATE SET
+                    last_sync = ?2,
+                    issue_count = ?3,
+                    issues_last_sync = COALESCE(?4, issues_last_sync),
+                    last_full_sync_attempt_at = ?5",
+                params![repo, now, issue_count, max_updated_at, now],
+            )?;
+        }
     } else if let Some(cursor) = &max_updated_at {
+        // Incremental sync
         tx.execute(
             "INSERT INTO sync_state (repo, last_sync, issue_count, issues_last_sync)
              VALUES (?1, ?2, ?3, ?4)

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -299,6 +299,16 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         )?;
     }
 
+    let has_last_full_sync_attempt_at: bool = conn
+        .prepare("SELECT last_full_sync_attempt_at FROM sync_state LIMIT 0")
+        .is_ok();
+    if !has_last_full_sync_attempt_at {
+        conn.execute(
+            "ALTER TABLE sync_state ADD COLUMN last_full_sync_attempt_at TEXT",
+            [],
+        )?;
+    }
+
     // Migration: add soft-delete columns to issues
     let has_issues_deleted: bool = conn
         .prepare("SELECT deleted FROM issues LIMIT 0")

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -15,14 +15,17 @@ pub struct SyncState {
     pub comments_last_sync: Option<String>,
     #[allow(dead_code)] // Will be used when goals incremental sync is implemented
     pub goals_last_sync: Option<String>,
-    /// Last full reconciliation timestamp
+    /// Last successful full reconciliation timestamp
     pub last_full_sync_at: Option<String>,
+    /// Last full sync attempt timestamp (regardless of success)
+    pub last_full_sync_attempt_at: Option<String>,
 }
 
 /// Get sync state for a repo
 pub fn get_sync_state(conn: &Connection, repo: &str) -> Result<Option<SyncState>> {
     let mut stmt = conn.prepare(
-        "SELECT last_sync, issue_count, issues_last_sync, comments_last_sync, goals_last_sync, last_full_sync_at
+        "SELECT last_sync, issue_count, issues_last_sync, comments_last_sync, goals_last_sync,
+                last_full_sync_at, last_full_sync_attempt_at
          FROM sync_state WHERE repo = ?",
     )?;
 
@@ -36,6 +39,7 @@ pub fn get_sync_state(conn: &Connection, repo: &str) -> Result<Option<SyncState>
             comments_last_sync: row.get(3)?,
             goals_last_sync: row.get(4)?,
             last_full_sync_at: row.get(5)?,
+            last_full_sync_attempt_at: row.get(6)?,
         }))
     } else {
         Ok(None)

--- a/src/forges/linear/client.rs
+++ b/src/forges/linear/client.rs
@@ -371,7 +371,13 @@ impl LinearClient {
                     cursor = page_info.end_cursor;
                 }
                 Err(e) => {
-                    eprintln!("Warning: Linear issues page fetch failed: {}", e);
+                    let err_str = e.to_string();
+                    // Rate limit errors (429) should be propagated, not swallowed
+                    if err_str.contains("429") {
+                        return Err(e);
+                    }
+                    // Other errors: return partial data
+                    eprintln!("Warning: Linear issues page fetch failed: {}", err_str);
                     return Ok(FetchResult::incomplete(all_issues));
                 }
             }
@@ -739,7 +745,13 @@ impl LinearClient {
                     cursor = page_info.end_cursor;
                 }
                 Err(e) => {
-                    eprintln!("Warning: Linear comments page fetch failed: {}", e);
+                    let err_str = e.to_string();
+                    // Rate limit errors (429) should be propagated, not swallowed
+                    if err_str.contains("429") {
+                        return Err(e);
+                    }
+                    // Other errors: return partial data
+                    eprintln!("Warning: Linear comments page fetch failed: {}", err_str);
                     return Ok(FetchResult::incomplete(all_comments));
                 }
             }


### PR DESCRIPTION
## Summary
- Fixes infinite sync retry loop caused by failed full syncs (observed 20,967 attempts for one repo)
- Propagates 429 rate limit errors from Linear client instead of swallowing as "incomplete"
- Adds 15-minute cooldown after any failed full sync attempt to prevent retry storms

## Root Cause
When a full sync returned `incomplete`, the daemon would:
1. Not update `last_full_sync_at` (correct - sync didn't succeed)
2. Retry full sync next cycle (15s) since no success timestamp
3. Loop indefinitely, hammering the API

The fix adds `last_full_sync_attempt_at` to track attempts regardless of success, with a 15-minute cooldown.

## Test plan
- [x] `cargo test` passes (99 tests)
- [x] Verified all scenarios: rate limit errors, network errors, cooldown with/without cursor

🤖 Generated with [Claude Code](https://claude.com/claude-code)