### PR TITLE
Default issue list to open issues

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -125,9 +125,13 @@ pub enum IssueCommands {
         #[arg(long)]
         label: Option<String>,
 
-        /// Filter by state (open, closed)
+        /// Filter by state (open, closed, all). Defaults to open.
         #[arg(long)]
         state: Option<String>,
+
+        /// Show all issues (including closed). Shorthand for --state=all.
+        #[arg(long)]
+        all: bool,
 
         /// Show only issues assigned to me
         #[arg(long)]

--- a/src/cli/issues.rs
+++ b/src/cli/issues.rs
@@ -18,6 +18,7 @@ pub async fn cmd_list(
     id: Option<String>,
     label: Option<String>,
     state: Option<String>,
+    all: bool,
     mine: bool,
     unassigned: bool,
     open: bool,
@@ -123,9 +124,13 @@ pub async fn cmd_list(
     // Touch repo to update last_accessed for daemon priority
     db::touch_repo(&conn, &repo_path)?;
 
-    // --open is a shorthand for --state=open
-    let state = if open && state.is_none() {
+    // Default to open unless --all, --state=all, or explicit --state provided
+    let state = if all || state.as_deref() == Some("all") {
+        None // No state filtering
+    } else if open && state.is_none() {
         Some("open".to_string())
+    } else if state.is_none() {
+        Some("open".to_string()) // Default to open
     } else {
         state
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ async fn main() -> Result<()> {
                 id,
                 label,
                 state,
+                all,
                 mine,
                 unassigned,
                 open,
@@ -40,7 +41,7 @@ async fn main() -> Result<()> {
                 opt,
                 json,
             } => {
-                cli::issues::cmd_list(view, id, label, state, mine, unassigned, open, goal, sort, opt, json)
+                cli::issues::cmd_list(view, id, label, state, all, mine, unassigned, open, goal, sort, opt, json)
                     .await?
             }
             IssueCommands::Show { id, json } => cli::issues::cmd_show(&id, json)?,


### PR DESCRIPTION
## Summary
- Change `isq issue list` to show only open issues by default, matching `gh issue list` behavior
- Add `--all` flag to see all issues (shorthand for `--state=all`)
- Support `state = "all"` in views to show all issues

## Test plan
- [x] `isq issue list` shows only open issues
- [x] `isq issue list --all` shows all issues
- [x] `isq issue list --state=closed` shows closed only
- [x] Views with `state = "all"` show all issues
- [x] All 126 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)