### PR TITLE
Add GitHub repo link to help output

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -18,6 +18,7 @@ fn parse_view_arg(s: &str) -> Result<String, String> {
 #[command(name = "isq")]
 #[command(about = "Instant issue tracking. Offline-first. AI-agent native.")]
 #[command(version)]
+#[command(after_help = "https://github.com/camwest/isq")]
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Commands>,


### PR DESCRIPTION
## Summary
- Add GitHub repo URL to the bottom of `isq --help` output using clap's `after_help` attribute

## Test plan
- [x] `cargo build` - compiles successfully
- [x] `cargo run -- --help` - URL appears at bottom
- [x] `cargo test` - all 126 tests pass

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)