### PR TITLE
Add examples to issue create help text

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -174,6 +174,13 @@ pub enum IssueCommands {
     },
 
     /// Create a new issue
+    #[command(after_help = "\
+Examples:
+  isq issue create --title \"Bug: login fails\"
+  isq issue create --title \"Feature\" --body \"Details here\" --label enhancement
+  isq issue create --title \"Urgent fix\" --label bug --label critical
+  isq issue create --title \"Sprint task\" --goal \"v1.0\"
+")]
     Create {
         /// Issue title
         #[arg(long)]


### PR DESCRIPTION
## Summary
- Add usage examples to `isq issue create --help` output
- Users can now copy-paste working examples instead of constructing commands from flag descriptions

## Test plan
- [x] `cargo build` succeeds
- [x] `isq issue create --help` shows examples at the bottom
- [x] `cargo test` passes (126 tests)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)