### PR TITLE
Support piping content into issue create and comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ isq issue list --sort priority           # Sort by priority (default)
 isq issue create --title "Fix login bug"
 isq issue comment 423 "Fixed in abc123"
 isq issue close 423
+
+# Pipe content from files or clipboard
+cat description.md | isq issue create --title "Feature request"
+pbpaste | isq issue comment 423
 ```
 
 ## Development Workflow

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -189,7 +189,7 @@ Examples:
         #[arg(long)]
         title: String,
 
-        /// Issue body
+        /// Issue body (can also be piped via stdin)
         #[arg(long)]
         body: Option<String>,
 
@@ -215,8 +215,8 @@ Examples:
         /// Issue ID (e.g., 123 or DEV-123)
         id: String,
 
-        /// Comment body
-        message: String,
+        /// Comment body (can also be piped via stdin)
+        message: Option<String>,
 
         /// Output as JSON
         #[arg(long)]

--- a/src/cli/issues.rs
+++ b/src/cli/issues.rs
@@ -306,6 +306,9 @@ pub async fn cmd_create(
     json: bool,
     cli_quiet: bool,
 ) -> Result<()> {
+    // Resolve body: explicit arg takes precedence, then stdin
+    let body = body.or(super::utils::read_stdin_if_piped()?);
+
     // Apply json default from user config (CLI flag overrides)
     let json = crate::user_config::resolve_json_default(json)?;
     // Resolve quiet setting (CLI flag overrides config)
@@ -405,7 +408,18 @@ pub async fn cmd_create(
     Ok(())
 }
 
-pub async fn cmd_comment(id: &str, message: String, json: bool, cli_quiet: bool) -> Result<()> {
+pub async fn cmd_comment(id: &str, message: Option<String>, json: bool, cli_quiet: bool) -> Result<()> {
+    // Resolve message: explicit arg takes precedence, then stdin, then error
+    let message = message
+        .or(super::utils::read_stdin_if_piped()?)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Comment message required. Provide as argument or pipe via stdin.\n\
+                 Usage: isq issue comment <ID> \"message\"\n\
+                    or: echo \"message\" | isq issue comment <ID>"
+            )
+        })?;
+
     // Apply json default from user config (CLI flag overrides)
     let json = crate::user_config::resolve_json_default(json)?;
     // Resolve quiet setting (CLI flag overrides config)

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,5 +1,7 @@
 //! Shared CLI utilities
 
+use std::io::{self, IsTerminal, Read};
+
 use anyhow::Result;
 use serde::Serialize;
 
@@ -84,4 +86,21 @@ pub fn ensure_service_running() -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Read content from stdin if it's being piped (not a TTY).
+/// Returns None if stdin is a TTY (interactive mode).
+/// Returns Some(content) if stdin has piped content.
+pub fn read_stdin_if_piped() -> Result<Option<String>> {
+    let stdin = io::stdin();
+    if stdin.is_terminal() {
+        return Ok(None);
+    }
+    let mut content = String::new();
+    stdin.lock().read_to_string(&mut content)?;
+    let content = content.trim().to_string();
+    if content.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(content))
 }


### PR DESCRIPTION
## Summary
- Add stdin piping support for issue bodies and comments
- `cat description.md | isq issue create --title "Feature request"`
- `pbpaste | isq issue comment 42`

## Test plan
- [x] Test piped body: `echo "test" | cargo run -- issue create --title "Test"`
- [x] Test piped comment: `echo "comment" | cargo run -- issue comment <id>`
- [x] Verify explicit args still work
- [x] Run `cargo test`

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)