### PR TITLE
Add --no-color flag for explicit color control

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -23,6 +23,10 @@ pub struct Cli {
     #[arg(short, long, global = true)]
     pub quiet: bool,
 
+    /// Disable colored output
+    #[arg(long, global = true)]
+    pub no_color: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,11 @@ use crate::cli::{Cli, Commands, DaemonCommands, GoalCommands, IssueCommands, Lab
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Honor --no-color flag
+    if cli.no_color {
+        colored::control::set_override(false);
+    }
+
     match cli.command {
         None => cli::worktree::cmd_home()?,
         Some(Commands::Link { forge, opt }) => {


### PR DESCRIPTION
## Summary
- Add global `--no-color` flag to disable colored output
- Improves discoverability for CI environments, screen readers, and piped output
- Uses `colored::control::set_override()` to disable colors via the crate's API

Closes #37

## Test plan
- [x] `cargo test` passes (126 tests)
- [x] `isq --help` shows `--no-color` option
- [x] `isq issue --help` shows `--no-color` (global flag works on subcommands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)