### PR TITLE
Release workflow produces platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -23,6 +24,7 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+            linker: aarch64-linux-gnu-gcc
           - os: windows-latest
             target: x86_64-pc-windows-msvc
 
@@ -46,7 +48,7 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
         env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.target == 'aarch64-unknown-linux-gnu' && 'aarch64-linux-gnu-gcc' || '' }}
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: ${{ matrix.linker }}
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -58,10 +60,10 @@ jobs:
       - name: Package (Windows)
         if: runner.os == 'Windows'
         working-directory: target/${{ matrix.target }}/release
+        shell: bash
         run: |
-          7z a $env:ARCHIVE.zip isq.exe
-          $hash = (Get-FileHash "$env:ARCHIVE.zip" -Algorithm SHA256).Hash.ToLower()
-          "$hash  $env:ARCHIVE.zip" | Out-File -Encoding ascii "$env:ARCHIVE.zip.sha256"
+          7z a $ARCHIVE.zip isq.exe
+          sha256sum $ARCHIVE.zip > $ARCHIVE.zip.sha256
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Add Windows x86_64 target to release workflow
- Change asset naming from custom format to target triple format for self_update crate compatibility
- Package binaries as tar.gz (Unix) and zip (Windows) archives
- Generate SHA256 checksums per artifact and combined checksums.txt
- Fix Rust toolchain action name

## Test plan
- [ ] Push a test tag (e.g., `v0.0.0-test.1`)
- [ ] Verify workflow runs for all 5 targets
- [ ] Verify release has 5 archive files with correct naming
- [ ] Verify checksums.txt included with all checksums
- [ ] Download and verify checksums match

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)