### PR TITLE
Add `isq update check` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +435,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1850,6 +1869,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "io-close"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +1952,8 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rusqlite",
+ "self_update",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",
@@ -2155,6 +2189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,6 +2331,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,7 +2391,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2485,7 +2534,9 @@ checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2675,6 +2726,42 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "self_update"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469a3970061380c19852269f393e74c0fe607a4e23d85267382cf25486aa8de5"
+dependencies = [
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "self-replace",
+ "semver",
+ "serde_json",
+ "tempfile",
+ "urlencoding",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -3223,6 +3310,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ terminal_size = "0.4"
 libc = "0.2"
 gix = "0.72"
 toml = "0.8"
+self_update = { version = "0.41", default-features = false, features = ["rustls"] }
+semver = "1"
 
 # Keyring is kept temporarily for migrating existing credentials from OS keychain to file storage.
 # After sufficient migration period, this dependency can be removed entirely.

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -122,6 +122,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: InstallCommands,
     },
+
+    /// Check for and install updates
+    Update {
+        #[command(subcommand)]
+        command: UpdateCommands,
+    },
 }
 
 #[derive(Subcommand)]
@@ -506,5 +512,15 @@ pub enum InstallCommands {
         /// Enable auto-update
         #[arg(long)]
         auto_update: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum UpdateCommands {
+    /// Check if a newer version is available
+    Check {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
     },
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,8 +13,9 @@ pub mod labels;
 pub mod link;
 pub mod status;
 pub mod sync;
+pub mod update;
 mod utils;
 pub mod views;
 pub mod worktree;
 
-pub use args::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, ViewCommands};
+pub use args::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,0 +1,55 @@
+//! Update command handlers
+
+use anyhow::Result;
+use serde_json::json;
+
+use crate::install::{self, InstallMethod};
+use crate::updater;
+
+pub async fn cmd_check(json: bool) -> Result<()> {
+    let json = crate::user_config::resolve_json_default(json)?;
+    let receipt = install::read_receipt()?;
+
+    match updater::check_for_updates().await? {
+        Some(info) => {
+            if json {
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            } else {
+                println!("Current version: {}", info.current_version);
+                println!("Latest version:  {}", info.latest_version);
+                println!("Published:       {}", info.published_at);
+
+                if let Some(notes) = &info.release_notes {
+                    if !notes.is_empty() {
+                        println!("\nRelease notes:");
+                        let lines: Vec<_> = notes.lines().collect();
+                        for line in lines.iter().take(10) {
+                            println!("  {}", line);
+                        }
+                        if lines.len() > 10 {
+                            println!("  ...");
+                        }
+                    }
+                }
+
+                println!();
+                let update_cmd = match receipt.as_ref().map(|r| &r.install_method) {
+                    Some(InstallMethod::Homebrew) => "brew upgrade isq",
+                    Some(InstallMethod::Scoop) => "scoop update isq",
+                    Some(InstallMethod::Cargo) => "cargo install isq",
+                    _ => "isq update install",
+                };
+                println!("Run `{}` to update.", update_cmd);
+            }
+        }
+        None => {
+            let current = env!("CARGO_PKG_VERSION");
+            if json {
+                println!("{}", json!({"up_to_date": true, "version": current}));
+            } else {
+                println!("You're on the latest version ({})", current);
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,13 @@ mod install;
 mod pager;
 mod repo;
 mod service;
+mod updater;
 mod user_config;
 
 use anyhow::Result;
 use clap::Parser;
 
-use crate::cli::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, ViewCommands};
+use crate::cli::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -162,6 +163,9 @@ async fn main() -> Result<()> {
                 binary_path,
                 auto_update,
             } => cli::install::cmd_write_receipt(method, binary_path, auto_update)?,
+        },
+        Some(Commands::Update { command }) => match command {
+            UpdateCommands::Check { json } => cli::update::cmd_check(json).await?,
         },
     }
 

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,0 +1,96 @@
+//! Update checking logic using GitHub Releases API
+
+use anyhow::{anyhow, Result};
+use self_update::backends::github::ReleaseList;
+use semver::Version;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct UpdateInfo {
+    pub current_version: String,
+    pub latest_version: String,
+    pub download_url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_notes: Option<String>,
+    pub published_at: String,
+}
+
+/// Check for available updates from GitHub Releases
+///
+/// Returns Some(UpdateInfo) if a newer version is available, None if up to date.
+/// Skips prereleases (versions containing '-').
+///
+/// This function runs the blocking HTTP call in a separate thread to avoid
+/// blocking the async runtime.
+pub async fn check_for_updates() -> Result<Option<UpdateInfo>> {
+    // self_update uses blocking HTTP internally, so we need to run it
+    // in a blocking thread to avoid issues with the async runtime
+    tokio::task::spawn_blocking(check_for_updates_blocking)
+        .await?
+}
+
+fn check_for_updates_blocking() -> Result<Option<UpdateInfo>> {
+    let current = env!("CARGO_PKG_VERSION");
+
+    let releases = ReleaseList::configure()
+        .repo_owner("camwest")
+        .repo_name("isq")
+        .build()?
+        .fetch()?;
+
+    // Filter to stable releases only (skip prereleases)
+    let latest = releases
+        .iter()
+        .find(|r| !r.version.contains('-'))
+        .ok_or_else(|| anyhow!("No releases found"))?;
+
+    let current_v = Version::parse(current)?;
+    let latest_v = Version::parse(&latest.version)?;
+
+    if latest_v > current_v {
+        // Find download URL for current platform
+        let target = self_update::get_target();
+        let download_url = latest
+            .asset_for(target, None)
+            .map(|a| a.download_url)
+            .unwrap_or_default();
+
+        Ok(Some(UpdateInfo {
+            current_version: current.to_string(),
+            latest_version: latest.version.clone(),
+            download_url,
+            release_notes: latest.body.clone(),
+            published_at: latest.date.clone(),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_version_comparison() {
+        // These tests verify semver comparison logic
+        let v1 = Version::parse("0.1.0").unwrap();
+        let v2 = Version::parse("0.2.0").unwrap();
+        assert!(v2 > v1);
+
+        let v3 = Version::parse("0.2.0-beta").unwrap();
+        assert!(v2 > v3); // stable > prerelease
+
+        let v4 = Version::parse("1.0.0").unwrap();
+        let v5 = Version::parse("0.99.99").unwrap();
+        assert!(v4 > v5);
+    }
+
+    #[test]
+    fn test_prerelease_detection() {
+        assert!("0.2.0-beta".contains('-'));
+        assert!("0.2.0-rc.1".contains('-'));
+        assert!(!"0.2.0".contains('-'));
+        assert!(!"1.0.0".contains('-'));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `isq update check` command to check for updates via GitHub Releases API
- Uses `self_update` crate with rustls for cross-compilation compatibility
- Skips prereleases by default, only shows stable releases
- Integrates with install receipt system to show appropriate update command (brew/scoop/cargo/isq)
- Supports `--json` flag for machine-readable output

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` - all 137 tests pass
- [x] `isq update check` returns "No releases found" (expected - only prerelease exists)
- [x] `isq update check --json` works
- [x] `isq help update` shows command documentation

🤖 Generated with [Claude Code](https://claude.ai/code)