### PR TITLE
Add enhanced --version output with install method

### DIFF
--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -17,8 +17,11 @@ fn parse_view_arg(s: &str) -> Result<String, String> {
 #[derive(Parser)]
 #[command(name = "isq")]
 #[command(about = "Instant issue tracking. Offline-first. AI-agent native.")]
-#[command(version)]
 pub struct Cli {
+    /// Print version information
+    #[arg(short = 'V', long = "version")]
+    pub version: bool,
+
     /// Suppress success messages (errors still shown)
     #[arg(short, long, global = true)]
     pub quiet: bool,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,7 +15,9 @@ pub mod status;
 pub mod sync;
 pub mod update;
 mod utils;
+mod version;
 pub mod views;
 pub mod worktree;
 
 pub use args::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};
+pub use version::print_version;

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,0 +1,95 @@
+//! Version display with install method information
+
+use crate::install::{detect_install_method, read_receipt, InstallMethod};
+
+/// Format version string for a given install method
+fn format_version(version: &str, method: &InstallMethod, auto_update: bool) -> String {
+    match method {
+        InstallMethod::Standalone if auto_update => {
+            format!("isq {} (standalone, auto-updates enabled)", version)
+        }
+        InstallMethod::Standalone => format!("isq {} (standalone)", version),
+        InstallMethod::Homebrew => {
+            format!(
+                "isq {} (homebrew)\nNote: Run `brew upgrade isq` to update.",
+                version
+            )
+        }
+        InstallMethod::Scoop => {
+            format!(
+                "isq {} (scoop)\nNote: Run `scoop update isq` to update.",
+                version
+            )
+        }
+        InstallMethod::Cargo => {
+            format!(
+                "isq {} (cargo)\nNote: Run `cargo install isq` to update.",
+                version
+            )
+        }
+        InstallMethod::Unknown => format!("isq {}", version),
+    }
+}
+
+/// Print version info with install method and update instructions
+pub fn print_version() {
+    let version = env!("CARGO_PKG_VERSION");
+    let method = detect_install_method();
+    let auto_update = read_receipt()
+        .ok()
+        .flatten()
+        .map(|r| r.auto_update)
+        .unwrap_or(false);
+
+    println!("{}", format_version(version, &method, auto_update));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    #[test]
+    fn test_standalone_with_auto_update() {
+        let output = format_version(&VERSION, &InstallMethod::Standalone, true);
+        assert!(output.contains("standalone"));
+        assert!(output.contains("auto-updates enabled"));
+    }
+
+    #[test]
+    fn test_standalone_without_auto_update() {
+        let output = format_version(&VERSION, &InstallMethod::Standalone, false);
+        assert!(output.contains("standalone"));
+        assert!(!output.contains("auto-updates enabled"));
+    }
+
+    #[test]
+    fn test_homebrew_output() {
+        let output = format_version(&VERSION, &InstallMethod::Homebrew, false);
+        assert!(output.contains("homebrew"));
+        assert!(output.contains("brew upgrade isq"));
+    }
+
+    #[test]
+    fn test_scoop_output() {
+        let output = format_version(&VERSION, &InstallMethod::Scoop, false);
+        assert!(output.contains("scoop"));
+        assert!(output.contains("scoop update isq"));
+    }
+
+    #[test]
+    fn test_cargo_output() {
+        let output = format_version(&VERSION, &InstallMethod::Cargo, false);
+        assert!(output.contains("cargo"));
+        assert!(output.contains("cargo install isq"));
+    }
+
+    #[test]
+    fn test_unknown_minimal_output() {
+        let output = format_version(&VERSION, &InstallMethod::Unknown, false);
+        assert_eq!(output, format!("isq {}", VERSION));
+        assert!(!output.contains('('));
+        assert!(!output.contains("Note:"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,12 @@ async fn main() -> Result<()> {
         colored::control::set_override(false);
     }
 
+    // Handle --version before command routing
+    if cli.version {
+        cli::print_version();
+        return Ok(());
+    }
+
     match cli.command {
         None => cli::worktree::cmd_home()?,
         Some(Commands::Link { forge, opt }) => {


### PR DESCRIPTION
## Summary
- Shows install method (standalone/homebrew/scoop/cargo) in `isq --version` output
- Displays auto-update status for standalone installs
- Provides package manager update commands for non-standalone installs

## Examples
```
$ isq --version
isq 0.1.0 (standalone, auto-updates enabled)

$ isq --version
isq 0.1.0 (homebrew)
Note: Run `brew upgrade isq` to update.
```

## Test plan
- [x] `cargo test` passes (145 tests)
- [x] `isq --version` exits 0 and shows version
- [x] `isq -V` short flag works
- [x] Unknown install method shows minimal output

🤖 Generated with [Claude Code](https://claude.com/claude-code)