### PR TITLE
Fix Windows build: add explicit type annotation for rng.gen()

### DIFF
--- a/src/forges/jira/oauth.rs
+++ b/src/forges/jira/oauth.rs
@@ -53,7 +53,7 @@ pub struct JiraCredentials {
 /// Generate a random code verifier for PKCE (43-128 chars, URL-safe)
 fn generate_code_verifier() -> String {
     let mut rng = rand::thread_rng();
-    let bytes: Vec<u8> = (0..32).map(|_| rng.r#gen()).collect();
+    let bytes: Vec<u8> = (0..32).map(|_| rng.r#gen::<u8>()).collect();
     URL_SAFE_NO_PAD.encode(&bytes)
 }
 

--- a/src/forges/linear/oauth.rs
+++ b/src/forges/linear/oauth.rs
@@ -22,7 +22,7 @@ pub struct TokenResponse {
 /// Generate a random code verifier for PKCE (43-128 chars, URL-safe)
 fn generate_code_verifier() -> String {
     let mut rng = rand::thread_rng();
-    let bytes: Vec<u8> = (0..32).map(|_| rng.r#gen()).collect();
+    let bytes: Vec<u8> = (0..32).map(|_| rng.r#gen::<u8>()).collect();
     URL_SAFE_NO_PAD.encode(&bytes)
 }
 


### PR DESCRIPTION
## Summary
- Fixes Windows CI build failure caused by type inference ambiguity
- The `encode_unicode` crate provides conflicting `FromIterator` impls for `Vec<u8>` on Windows
- Adding `::<u8>` to `rng.gen()` calls resolves the ambiguity

## Test plan
- [x] Verified local build passes
- [ ] Windows CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)