### PR TITLE
Add standalone installer scripts

### DIFF
--- a/installers/install.ps1
+++ b/installers/install.ps1
@@ -81,7 +81,17 @@ function Install-Isq {
 
         Add-ToUserPath $installDir
 
+        # Verify binary runs
+        $installedVersion = & $binaryPath --version 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Installation completed but binary failed to run: $installedVersion"
+        }
+
+        # Write install receipt (warn on failure, don't abort)
         & $binaryPath install write-receipt --method standalone --binary-path $binaryPath --auto-update 2>$null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "warning: Failed to write install receipt" -ForegroundColor Yellow
+        }
 
         Write-Host ""
         Write-Ok "isq $version installed to $binaryPath"

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -151,8 +151,16 @@ install_binary() {
     echo "${install_dir}/isq"
 }
 
+verify_binary() {
+    if ! "$1" --version >/dev/null 2>&1; then
+        error "Installation completed but binary failed to run. Check library dependencies."
+    fi
+}
+
 write_receipt() {
-    "$1" install write-receipt --method standalone --binary-path "$1" --auto-update 2>/dev/null || true
+    if ! "$1" install write-receipt --method standalone --binary-path "$1" --auto-update 2>/dev/null; then
+        printf "${YELLOW}warning${NC}: Failed to write install receipt\n" >&2
+    fi
 }
 
 check_path() {
@@ -183,6 +191,7 @@ main() {
     tmpdir=$(download_and_verify "$version" "$target")
     install_spec=$(determine_install_dir)
     binary_path=$(install_binary "$tmpdir" "$install_spec")
+    verify_binary "$binary_path"
     write_receipt "$binary_path"
 
     install_dir="${install_spec#sudo:}"


### PR DESCRIPTION
## Summary

- Add `installers/install.sh` for macOS and Linux
- Add `installers/install.ps1` for Windows PowerShell

Both scripts:
- Download the appropriate binary from GitHub Releases
- Verify SHA256 checksum before installing
- Write install receipt for auto-update support

## Test plan

- [ ] Manual test: macOS ARM install
- [ ] Manual test: macOS Intel install
- [ ] Manual test: Linux x64 install
- [ ] Manual test: Windows install
- [ ] Verify install receipt written to `~/.config/isq/install.json`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)