### PR TITLE
Add daemon version check and auto-restart

### DIFF
--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -2,12 +2,47 @@
 
 use anyhow::Result;
 
+use crate::daemon;
 use crate::db;
-use crate::forges::{not_linked_error, ALL_FORGE_TYPES};
+use crate::forges::{ALL_FORGE_TYPES, not_linked_error};
 use crate::repo;
 use crate::service;
 
+/// Check if the daemon is running a stale version and restart if needed.
+///
+/// Compares the daemon's version (from PID file) with the current CLI version.
+/// If they differ, restarts the daemon to pick up the new binary.
+///
+/// Returns true if the daemon was restarted.
+pub fn ensure_daemon_current() -> Result<bool> {
+    let current = env!("CARGO_PKG_VERSION");
+
+    let info = match daemon::read_daemon_info()? {
+        Some(i) => i,
+        None => return Ok(false), // No daemon info file
+    };
+
+    // Check if daemon is actually running
+    if !service::status()?.running {
+        return Ok(false);
+    }
+
+    if info.version != current {
+        eprintln!("Restarting daemon (v{} -> v{})...", info.version, current);
+        service::stop()?;
+        service::start()?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
 pub fn cmd_status() -> Result<()> {
+    // Check if daemon needs restart for new version
+    if ensure_daemon_current()? {
+        println!("Daemon restarted for new version");
+    }
+
     // Check service status
     let status = service::status()?;
 

--- a/src/cli/forge.rs
+++ b/src/cli/forge.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-use crate::forges::{get_forge_for_repo, ForgeType, ALL_FORGE_TYPES};
+use crate::forges::{ALL_FORGE_TYPES, ForgeType, get_forge_for_repo};
 use crate::repo;
 
 pub async fn cmd_forge(forge_name: String, args: Vec<String>) -> Result<()> {

--- a/src/cli/goals.rs
+++ b/src/cli/goals.rs
@@ -6,10 +6,10 @@ use anyhow::Result;
 
 use crate::db;
 use crate::display;
-use crate::forges::{get_forge_for_repo, not_linked_error, CreateGoalRequest};
+use crate::forges::{CreateGoalRequest, get_forge_for_repo, not_linked_error};
 use crate::repo;
 
-use super::utils::{is_offline_error, WriteResult};
+use super::utils::{WriteResult, is_offline_error};
 
 pub async fn cmd_list(state: String, json_output: bool) -> Result<()> {
     // Apply json default from user config (CLI flag overrides)
@@ -76,12 +76,8 @@ pub fn cmd_show(name: String, json_output: bool) -> Result<()> {
 
     db::touch_repo(&conn, &repo_path)?;
 
-    let goal = db::load_goal_by_name(&conn, &link.forge_repo, &name)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Goal '{}' not found. Run `isq sync` to refresh.",
-            name
-        )
-    })?;
+    let goal = db::load_goal_by_name(&conn, &link.forge_repo, &name)?
+        .ok_or_else(|| anyhow::anyhow!("Goal '{}' not found. Run `isq sync` to refresh.", name))?;
 
     let elapsed = start.elapsed();
 
@@ -160,12 +156,7 @@ pub async fn cmd_create(
                 "description": body,
             });
             let conn = db::open()?;
-            db::queue_op(
-                &conn,
-                &link.forge_repo,
-                "create_goal",
-                &payload.to_string(),
-            )?;
+            db::queue_op(&conn, &link.forge_repo, "create_goal", &payload.to_string())?;
 
             if json {
                 let result = WriteResult {
@@ -190,7 +181,12 @@ pub async fn cmd_create(
     Ok(())
 }
 
-pub async fn cmd_assign(issue_id: &str, goal_name: String, json: bool, cli_quiet: bool) -> Result<()> {
+pub async fn cmd_assign(
+    issue_id: &str,
+    goal_name: String,
+    json: bool,
+    cli_quiet: bool,
+) -> Result<()> {
     // Apply json default from user config (CLI flag overrides)
     let json = crate::user_config::resolve_json_default(json)?;
     // Resolve quiet setting (CLI flag overrides config)
@@ -203,10 +199,7 @@ pub async fn cmd_assign(issue_id: &str, goal_name: String, json: bool, cli_quiet
 
     // Resolve goal name to ID
     let goal = db::load_goal_by_name(&conn, &link.forge_repo, &goal_name)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Goal '{}' not found. Run `isq sync` to refresh.",
-            goal_name
-        )
+        anyhow::anyhow!("Goal '{}' not found. Run `isq sync` to refresh.", goal_name)
     })?;
 
     let parts: Vec<&str> = link.forge_repo.split('/').collect();
@@ -246,12 +239,7 @@ pub async fn cmd_assign(issue_id: &str, goal_name: String, json: bool, cli_quiet
                 "issue_id": issue_id,
                 "goal_id": goal.id,
             });
-            db::queue_op(
-                &conn,
-                &link.forge_repo,
-                "assign_goal",
-                &payload.to_string(),
-            )?;
+            db::queue_op(&conn, &link.forge_repo, "assign_goal", &payload.to_string())?;
 
             if json {
                 let result = WriteResult {
@@ -289,9 +277,8 @@ pub async fn cmd_close(name: String, json: bool, cli_quiet: bool) -> Result<()> 
     let conn = db::open()?;
 
     // Resolve goal name to ID
-    let goal = db::load_goal_by_name(&conn, &link.forge_repo, &name)?.ok_or_else(|| {
-        anyhow::anyhow!("Goal '{}' not found. Run `isq sync` to refresh.", name)
-    })?;
+    let goal = db::load_goal_by_name(&conn, &link.forge_repo, &name)?
+        .ok_or_else(|| anyhow::anyhow!("Goal '{}' not found. Run `isq sync` to refresh.", name))?;
 
     let parts: Vec<&str> = link.forge_repo.split('/').collect();
     if parts.len() != 2 {

--- a/src/cli/issues.rs
+++ b/src/cli/issues.rs
@@ -8,11 +8,11 @@ use anyhow::Result;
 use crate::config;
 use crate::db;
 use crate::display;
-use crate::forges::{get_forge_for_repo, not_linked_error, CreateIssueRequest, Issue};
+use crate::forges::{CreateIssueRequest, Issue, get_forge_for_repo, not_linked_error};
 use crate::pager;
 use crate::repo;
 
-use super::utils::{is_offline_error, parse_issue_number, WriteResult};
+use super::utils::{WriteResult, is_offline_error, parse_issue_number};
 
 pub async fn cmd_list(
     view: Option<String>,
@@ -35,42 +35,76 @@ pub async fn cmd_list(
 
     // Expand view if specified, merging with CLI args (CLI wins)
     // View fields that don't have CLI equivalents are passed through directly
-    let (label, label_not, label_any, state, mine, unassigned, goal, sort, priority, priority_lte, priority_gte, updated_before, updated_after, created_before, created_after) =
-        if let Some(ref view_name) = view {
-            let view_def = user_config
-                .views
-                .get(view_name)
-                .ok_or_else(|| anyhow::anyhow!("Unknown view: @{}. Use 'isq view list' to see available views.", view_name))?;
+    let (
+        label,
+        label_not,
+        label_any,
+        state,
+        mine,
+        unassigned,
+        goal,
+        sort,
+        priority,
+        priority_lte,
+        priority_gte,
+        updated_before,
+        updated_after,
+        created_before,
+        created_after,
+    ) = if let Some(ref view_name) = view {
+        let view_def = user_config.views.get(view_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Unknown view: @{}. Use 'isq view list' to see available views.",
+                view_name
+            )
+        })?;
 
-            // Merge: CLI args override view settings
-            let merged_label = label.or_else(|| view_def.label.clone());
-            let merged_label_not = view_def.label_not.clone();
-            let merged_label_any = view_def.label_any.clone();
-            let merged_state = state.or_else(|| view_def.state.clone());
-            let merged_mine = mine || view_def.mine;
-            let merged_unassigned = unassigned || view_def.unassigned;
-            let merged_goal = goal.or_else(|| view_def.goal.clone());
-            let merged_sort = if sort != "priority" {
-                sort // CLI provided explicit sort
-            } else {
-                view_def.sort.clone().unwrap_or(sort)
-            };
-            // Priority filters from view
-            let merged_priority = view_def.priority;
-            let merged_priority_lte = view_def.priority_lte;
-            let merged_priority_gte = view_def.priority_gte;
-            // Date filters from view
-            let merged_updated_before = view_def.updated_before.clone();
-            let merged_updated_after = view_def.updated_after.clone();
-            let merged_created_before = view_def.created_before.clone();
-            let merged_created_after = view_def.created_after.clone();
-
-            (merged_label, merged_label_not, merged_label_any, merged_state, merged_mine, merged_unassigned,
-             merged_goal, merged_sort, merged_priority, merged_priority_lte, merged_priority_gte,
-             merged_updated_before, merged_updated_after, merged_created_before, merged_created_after)
+        // Merge: CLI args override view settings
+        let merged_label = label.or_else(|| view_def.label.clone());
+        let merged_label_not = view_def.label_not.clone();
+        let merged_label_any = view_def.label_any.clone();
+        let merged_state = state.or_else(|| view_def.state.clone());
+        let merged_mine = mine || view_def.mine;
+        let merged_unassigned = unassigned || view_def.unassigned;
+        let merged_goal = goal.or_else(|| view_def.goal.clone());
+        let merged_sort = if sort != "priority" {
+            sort // CLI provided explicit sort
         } else {
-            (label, None, None, state, mine, unassigned, goal, sort, None, None, None, None, None, None, None)
+            view_def.sort.clone().unwrap_or(sort)
         };
+        // Priority filters from view
+        let merged_priority = view_def.priority;
+        let merged_priority_lte = view_def.priority_lte;
+        let merged_priority_gte = view_def.priority_gte;
+        // Date filters from view
+        let merged_updated_before = view_def.updated_before.clone();
+        let merged_updated_after = view_def.updated_after.clone();
+        let merged_created_before = view_def.created_before.clone();
+        let merged_created_after = view_def.created_after.clone();
+
+        (
+            merged_label,
+            merged_label_not,
+            merged_label_any,
+            merged_state,
+            merged_mine,
+            merged_unassigned,
+            merged_goal,
+            merged_sort,
+            merged_priority,
+            merged_priority_lte,
+            merged_priority_gte,
+            merged_updated_before,
+            merged_updated_after,
+            merged_created_before,
+            merged_created_after,
+        )
+    } else {
+        (
+            label, None, None, state, mine, unassigned, goal, sort, None, None, None, None, None,
+            None, None,
+        )
+    };
 
     // Parse forge-specific options
     let opts = crate::forges::parse_opts(&opts);
@@ -247,7 +281,9 @@ pub fn cmd_show(id: &str, json_output: bool) -> Result<()> {
             if !prefix.eq_ignore_ascii_case(project_key) {
                 anyhow::bail!(
                     "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
-                    id, prefix, project_key
+                    id,
+                    prefix,
+                    project_key
                 );
             }
         }
@@ -326,10 +362,7 @@ pub async fn cmd_create(
     // Resolve goal name to goal_id if provided
     let goal_id = if let Some(goal_name) = &goal {
         let g = db::load_goal_by_name(&conn, &link.forge_repo, goal_name)?.ok_or_else(|| {
-            anyhow::anyhow!(
-                "Goal '{}' not found. Run `isq sync` to refresh.",
-                goal_name
-            )
+            anyhow::anyhow!("Goal '{}' not found. Run `isq sync` to refresh.", goal_name)
         })?;
         Some(g.id)
     } else {
@@ -408,7 +441,12 @@ pub async fn cmd_create(
     Ok(())
 }
 
-pub async fn cmd_comment(id: &str, message: Option<String>, json: bool, cli_quiet: bool) -> Result<()> {
+pub async fn cmd_comment(
+    id: &str,
+    message: Option<String>,
+    json: bool,
+    cli_quiet: bool,
+) -> Result<()> {
     // Resolve message: explicit arg takes precedence, then stdin, then error
     let message = message
         .or(super::utils::read_stdin_if_piped()?)
@@ -449,7 +487,9 @@ pub async fn cmd_comment(id: &str, message: Option<String>, json: bool, cli_quie
             if !prefix.eq_ignore_ascii_case(project_key) {
                 anyhow::bail!(
                     "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
-                    id, prefix, project_key
+                    id,
+                    prefix,
+                    project_key
                 );
             }
         }
@@ -470,7 +510,11 @@ pub async fn cmd_comment(id: &str, message: Option<String>, json: bool, cli_quie
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else if !quiet {
-                println!("✓ Comment added to {} ({:.0}ms)", issue_display, elapsed.as_millis());
+                println!(
+                    "✓ Comment added to {} ({:.0}ms)",
+                    issue_display,
+                    elapsed.as_millis()
+                );
             }
         }
         Err(e) if is_offline_error(&e) => {
@@ -534,7 +578,9 @@ pub async fn cmd_close(id: &str, json: bool, cli_quiet: bool) -> Result<()> {
             if !prefix.eq_ignore_ascii_case(project_key) {
                 anyhow::bail!(
                     "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
-                    id, prefix, project_key
+                    id,
+                    prefix,
+                    project_key
                 );
             }
         }
@@ -615,7 +661,9 @@ pub async fn cmd_reopen(id: &str, json: bool, cli_quiet: bool) -> Result<()> {
             if !prefix.eq_ignore_ascii_case(project_key) {
                 anyhow::bail!(
                     "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
-                    id, prefix, project_key
+                    id,
+                    prefix,
+                    project_key
                 );
             }
         }
@@ -636,7 +684,11 @@ pub async fn cmd_reopen(id: &str, json: bool, cli_quiet: bool) -> Result<()> {
                 };
                 println!("{}", serde_json::to_string_pretty(&result)?);
             } else if !quiet {
-                println!("✓ Reopened {} ({:.0}ms)", issue_display, elapsed.as_millis());
+                println!(
+                    "✓ Reopened {} ({:.0}ms)",
+                    issue_display,
+                    elapsed.as_millis()
+                );
             }
         }
         Err(e) if is_offline_error(&e) => {
@@ -667,7 +719,13 @@ pub async fn cmd_reopen(id: &str, json: bool, cli_quiet: bool) -> Result<()> {
     Ok(())
 }
 
-pub async fn cmd_label(id: &str, action: String, label: String, json: bool, cli_quiet: bool) -> Result<()> {
+pub async fn cmd_label(
+    id: &str,
+    action: String,
+    label: String,
+    json: bool,
+    cli_quiet: bool,
+) -> Result<()> {
     // Apply json default from user config (CLI flag overrides)
     let json = crate::user_config::resolve_json_default(json)?;
     // Resolve quiet setting (CLI flag overrides config)
@@ -696,7 +754,9 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool, cli_
             if !prefix.eq_ignore_ascii_case(project_key) {
                 anyhow::bail!(
                     "Issue '{}' belongs to project '{}', but you're linked to '{}'.",
-                    id, prefix, project_key
+                    id,
+                    prefix,
+                    project_key
                 );
             }
         }
@@ -705,113 +765,109 @@ pub async fn cmd_label(id: &str, action: String, label: String, json: bool, cli_
     let issue_display = display::format_issue_id(issue_id);
 
     match action.as_str() {
-        "add" => {
-            match forge.add_label(&repo_struct, issue_id, &label).await {
-                Ok(()) => {
-                    let elapsed = start.elapsed();
-                    if json {
-                        let result = WriteResult {
-                            success: true,
-                            queued: false,
-                            issue_id: Some(issue_id.to_string()),
-                            message: format!("Added label '{}' to {}", label, issue_display),
-                            elapsed_ms: elapsed.as_millis() as u64,
-                        };
-                        println!("{}", serde_json::to_string_pretty(&result)?);
-                    } else if !quiet {
-                        println!(
-                            "✓ Added label '{}' to {} ({:.0}ms)",
-                            label,
-                            issue_display,
-                            elapsed.as_millis()
-                        );
-                    }
+        "add" => match forge.add_label(&repo_struct, issue_id, &label).await {
+            Ok(()) => {
+                let elapsed = start.elapsed();
+                if json {
+                    let result = WriteResult {
+                        success: true,
+                        queued: false,
+                        issue_id: Some(issue_id.to_string()),
+                        message: format!("Added label '{}' to {}", label, issue_display),
+                        elapsed_ms: elapsed.as_millis() as u64,
+                    };
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else if !quiet {
+                    println!(
+                        "✓ Added label '{}' to {} ({:.0}ms)",
+                        label,
+                        issue_display,
+                        elapsed.as_millis()
+                    );
                 }
-                Err(e) if is_offline_error(&e) => {
-                    let elapsed = start.elapsed();
-                    let payload = serde_json::json!({
-                        "issue_id": issue_id,
-                        "label": label,
-                    });
-                    let conn = db::open()?;
-                    db::queue_op(&conn, &link.forge_repo, "label_add", &payload.to_string())?;
-                    if json {
-                        let result = WriteResult {
-                            success: true,
-                            queued: true,
-                            issue_id: Some(issue_id.to_string()),
-                            message: format!("Queued: add label '{}' to {}", label, issue_display),
-                            elapsed_ms: elapsed.as_millis() as u64,
-                        };
-                        println!("{}", serde_json::to_string_pretty(&result)?);
-                    } else if !quiet {
-                        println!(
-                            "✓ Queued: add label '{}' to {} (offline, {:.0}ms)",
-                            label,
-                            issue_display,
-                            elapsed.as_millis()
-                        );
-                    }
-                }
-                Err(e) => return Err(e),
             }
-        }
-        "remove" => {
-            match forge.remove_label(&repo_struct, issue_id, &label).await {
-                Ok(()) => {
-                    let elapsed = start.elapsed();
-                    if json {
-                        let result = WriteResult {
-                            success: true,
-                            queued: false,
-                            issue_id: Some(issue_id.to_string()),
-                            message: format!("Removed label '{}' from {}", label, issue_display),
-                            elapsed_ms: elapsed.as_millis() as u64,
-                        };
-                        println!("{}", serde_json::to_string_pretty(&result)?);
-                    } else if !quiet {
-                        println!(
-                            "✓ Removed label '{}' from {} ({:.0}ms)",
-                            label,
-                            issue_display,
-                            elapsed.as_millis()
-                        );
-                    }
+            Err(e) if is_offline_error(&e) => {
+                let elapsed = start.elapsed();
+                let payload = serde_json::json!({
+                    "issue_id": issue_id,
+                    "label": label,
+                });
+                let conn = db::open()?;
+                db::queue_op(&conn, &link.forge_repo, "label_add", &payload.to_string())?;
+                if json {
+                    let result = WriteResult {
+                        success: true,
+                        queued: true,
+                        issue_id: Some(issue_id.to_string()),
+                        message: format!("Queued: add label '{}' to {}", label, issue_display),
+                        elapsed_ms: elapsed.as_millis() as u64,
+                    };
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else if !quiet {
+                    println!(
+                        "✓ Queued: add label '{}' to {} (offline, {:.0}ms)",
+                        label,
+                        issue_display,
+                        elapsed.as_millis()
+                    );
                 }
-                Err(e) if is_offline_error(&e) => {
-                    let elapsed = start.elapsed();
-                    let payload = serde_json::json!({
-                        "issue_id": issue_id,
-                        "label": label,
-                    });
-                    let conn = db::open()?;
-                    db::queue_op(
-                        &conn,
-                        &link.forge_repo,
-                        "label_remove",
-                        &payload.to_string(),
-                    )?;
-                    if json {
-                        let result = WriteResult {
-                            success: true,
-                            queued: true,
-                            issue_id: Some(issue_id.to_string()),
-                            message: format!("Queued: remove label '{}' from {}", label, issue_display),
-                            elapsed_ms: elapsed.as_millis() as u64,
-                        };
-                        println!("{}", serde_json::to_string_pretty(&result)?);
-                    } else if !quiet {
-                        println!(
-                            "✓ Queued: remove label '{}' from {} (offline, {:.0}ms)",
-                            label,
-                            issue_display,
-                            elapsed.as_millis()
-                        );
-                    }
-                }
-                Err(e) => return Err(e),
             }
-        }
+            Err(e) => return Err(e),
+        },
+        "remove" => match forge.remove_label(&repo_struct, issue_id, &label).await {
+            Ok(()) => {
+                let elapsed = start.elapsed();
+                if json {
+                    let result = WriteResult {
+                        success: true,
+                        queued: false,
+                        issue_id: Some(issue_id.to_string()),
+                        message: format!("Removed label '{}' from {}", label, issue_display),
+                        elapsed_ms: elapsed.as_millis() as u64,
+                    };
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else if !quiet {
+                    println!(
+                        "✓ Removed label '{}' from {} ({:.0}ms)",
+                        label,
+                        issue_display,
+                        elapsed.as_millis()
+                    );
+                }
+            }
+            Err(e) if is_offline_error(&e) => {
+                let elapsed = start.elapsed();
+                let payload = serde_json::json!({
+                    "issue_id": issue_id,
+                    "label": label,
+                });
+                let conn = db::open()?;
+                db::queue_op(
+                    &conn,
+                    &link.forge_repo,
+                    "label_remove",
+                    &payload.to_string(),
+                )?;
+                if json {
+                    let result = WriteResult {
+                        success: true,
+                        queued: true,
+                        issue_id: Some(issue_id.to_string()),
+                        message: format!("Queued: remove label '{}' from {}", label, issue_display),
+                        elapsed_ms: elapsed.as_millis() as u64,
+                    };
+                    println!("{}", serde_json::to_string_pretty(&result)?);
+                } else if !quiet {
+                    println!(
+                        "✓ Queued: remove label '{}' from {} (offline, {:.0}ms)",
+                        label,
+                        issue_display,
+                        elapsed.as_millis()
+                    );
+                }
+            }
+            Err(e) => return Err(e),
+        },
         _ => {
             anyhow::bail!("Invalid action '{}'. Use 'add' or 'remove'.", action);
         }

--- a/src/cli/labels.rs
+++ b/src/cli/labels.rs
@@ -73,7 +73,12 @@ pub async fn cmd_create(
     };
 
     let label = forge
-        .create_label(&repo_struct, &name, color.as_deref(), description.as_deref())
+        .create_label(
+            &repo_struct,
+            &name,
+            color.as_deref(),
+            description.as_deref(),
+        )
         .await?;
     let elapsed = start.elapsed();
 

--- a/src/cli/link.rs
+++ b/src/cli/link.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::credentials;
 use crate::db;
-use crate::forges::{ForgeType, LinkArgs, ALL_FORGE_TYPES};
+use crate::forges::{ALL_FORGE_TYPES, ForgeType, LinkArgs};
 use crate::repo;
 use crate::service;
 
@@ -19,10 +19,7 @@ pub async fn cmd_link(forge_name: Option<&str>, opts: Vec<String>) -> Result<()>
             .iter()
             .map(|f| format!("  isq link {}", f.as_str()))
             .collect();
-        anyhow::anyhow!(
-            "Missing forge name.\n\nRun one of:\n{}",
-            forges.join("\n")
-        )
+        anyhow::anyhow!("Missing forge name.\n\nRun one of:\n{}", forges.join("\n"))
     })?;
 
     // Parse forge type
@@ -97,10 +94,7 @@ pub fn cmd_logout(forge_name: Option<&str>) -> Result<()> {
             .iter()
             .map(|f| format!("  isq logout {}", f.as_str()))
             .collect();
-        anyhow::anyhow!(
-            "Missing forge name.\n\nRun one of:\n{}",
-            forges.join("\n")
-        )
+        anyhow::anyhow!("Missing forge name.\n\nRun one of:\n{}", forges.join("\n"))
     })?;
 
     let forge_type = ForgeType::from_str(forge_name).ok_or_else(|| {
@@ -128,10 +122,7 @@ pub fn cmd_logout(forge_name: Option<&str>) -> Result<()> {
 
     // Note about env vars if relevant
     if std::env::var(auth.env_var).is_ok() {
-        println!(
-            "  Note: {} is still set in your environment",
-            auth.env_var
-        );
+        println!("  Note: {} is still set in your environment", auth.env_var);
     }
 
     Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,5 +19,8 @@ mod version;
 pub mod views;
 pub mod worktree;
 
-pub use args::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};
+pub use args::{
+    Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands,
+    UpdateCommands, ViewCommands,
+};
 pub use version::print_version;

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -47,7 +47,9 @@ pub fn parse_issue_number(id: &str, expected_prefix: Option<&str>) -> Result<u64
                     anyhow::bail!(
                         "Issue '{}' belongs to project '{}', but you're linked to '{}'. \
                          Cross-project operations will be supported in a future release (see issue #74).",
-                        id, prefix, expected
+                        id,
+                        prefix,
+                        expected
                     );
                 }
             }

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -1,6 +1,6 @@
 //! Version display with install method information
 
-use crate::install::{detect_install_method, read_receipt, InstallMethod};
+use crate::install::{InstallMethod, detect_install_method, read_receipt};
 
 /// Format version string for a given install method
 fn format_version(version: &str, method: &InstallMethod, auto_update: bool) -> String {

--- a/src/cli/views.rs
+++ b/src/cli/views.rs
@@ -2,7 +2,7 @@
 //!
 //! Handles creation, listing, showing, and deletion of custom views.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 
 use crate::user_config::{self, View};
 

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -83,8 +83,9 @@ pub async fn cmd_start(id: String) -> Result<()> {
 
     // Load issue from cache (fast!)
     let issue_display = display::format_issue_id(&id);
-    let issue = db::load_issue(&conn, &link.forge_repo, &id)?
-        .ok_or_else(|| anyhow::anyhow!("Issue {} not found. Run `isq sync` first.", issue_display))?;
+    let issue = db::load_issue(&conn, &link.forge_repo, &id)?.ok_or_else(|| {
+        anyhow::anyhow!("Issue {} not found. Run `isq sync` first.", issue_display)
+    })?;
 
     // Create branch name: {id}-{slugified-title}
     let branch = format!("{}-{}", id, repo::slugify(&issue.title));
@@ -121,8 +122,7 @@ pub async fn cmd_start(id: String) -> Result<()> {
     let id_for_db = id.clone();
     let id_for_setup = id.clone();
     let id_for_forge = id.clone();
-    let db_future =
-        async { db::set_worktree_issue(&conn, &git_dir_str, &forge_repo, &id_for_db) };
+    let db_future = async { db::set_worktree_issue(&conn, &git_dir_str, &forge_repo, &id_for_db) };
 
     let setup_future = async {
         if let Some(ref cfg) = repo_config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -168,7 +168,8 @@ fn generate_config_content(repo_path: &Path, forge_type: &str) -> String {
 
     // On-start section - forge-specific defaults
     content.push_str("[on_start]\n");
-    let ft = ForgeType::from_str(forge_type).expect("invalid forge type passed to config generation");
+    let ft =
+        ForgeType::from_str(forge_type).expect("invalid forge type passed to config generation");
     content.push_str(ft.default_on_start_toml());
     content.push('\n');
 
@@ -248,7 +249,10 @@ custom_field = "whatever"
     fn test_detect_node_npm() {
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("package.json"), "{}").unwrap();
-        assert_eq!(detect_project_type(temp.path()), ProjectType::Node(NodePackageManager::Npm));
+        assert_eq!(
+            detect_project_type(temp.path()),
+            ProjectType::Node(NodePackageManager::Npm)
+        );
     }
 
     #[test]
@@ -256,7 +260,10 @@ custom_field = "whatever"
         let temp = tempfile::tempdir().unwrap();
         std::fs::write(temp.path().join("package.json"), "{}").unwrap();
         std::fs::write(temp.path().join("pnpm-lock.yaml"), "").unwrap();
-        assert_eq!(detect_project_type(temp.path()), ProjectType::Node(NodePackageManager::Pnpm));
+        assert_eq!(
+            detect_project_type(temp.path()),
+            ProjectType::Node(NodePackageManager::Pnpm)
+        );
     }
 
     #[test]

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,16 +1,16 @@
 use anyhow::Result;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::stream::{self, StreamExt};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
 
 use crate::db;
-use crate::forges::{get_forge_for_repo, CreateIssueRequest, FetchResult, Forge};
+use crate::forges::{CreateIssueRequest, FetchResult, Forge, get_forge_for_repo};
 use crate::repo::Repo;
 
 // Sync all repos at this interval
@@ -19,6 +19,15 @@ const MAX_BACKOFF_SECS: u64 = 3600; // Max 1 hour backoff
 const FULL_SYNC_INTERVAL_HOURS: i64 = 1; // Hours between full reconciliation syncs
 const MAX_CONCURRENT_SYNCS: usize = 4; // Max repos to sync in parallel
 const FULL_SYNC_RETRY_COOLDOWN_MINS: i64 = 15; // Minutes to wait after failed full sync attempt
+const VERSION_CHECK_INTERVAL_SECS: u64 = 300; // 5 minutes - check if binary was updated
+
+/// Information about the running daemon, stored in the PID file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonInfo {
+    pub pid: u32,
+    pub version: String,
+    pub started_at: DateTime<Utc>,
+}
 
 /// Get the daemon PID file path
 pub fn pid_path() -> Result<PathBuf> {
@@ -70,6 +79,28 @@ fn acquire_lock() -> Result<File> {
     Ok(File::create(&path)?)
 }
 
+/// Write daemon info to the PID file in JSON format.
+fn write_daemon_info(info: &DaemonInfo) -> Result<()> {
+    let pid_file = pid_path()?;
+    let content = serde_json::to_string_pretty(info)?;
+    fs::write(&pid_file, content)?;
+    Ok(())
+}
+
+/// Read daemon info from the PID file.
+///
+/// Returns None if file doesn't exist or is invalid JSON.
+pub fn read_daemon_info() -> Result<Option<DaemonInfo>> {
+    let pid_file = pid_path()?;
+
+    if !pid_file.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&pid_file)?;
+    Ok(serde_json::from_str(&content).ok())
+}
+
 /// Per-repo sync state for backoff tracking
 struct RepoSyncState {
     consecutive_failures: u32,
@@ -104,18 +135,27 @@ fn calculate_backoff(failures: u32) -> Duration {
 /// Repos are sorted by last_accessed (most recent first) so that if we can't
 /// finish all repos before the next cycle (due to rate limits or too many repos),
 /// the ones you're actively using get priority.
+///
+/// Also checks every VERSION_CHECK_INTERVAL_SECS if the binary on disk has been
+/// updated, and exits gracefully to allow the service manager to restart with
+/// the new version.
 pub async fn run_loop() -> Result<()> {
     // Acquire exclusive lock FIRST - prevents multiple instances
     let _lock = acquire_lock()?;
     eprintln!("[daemon] Acquired exclusive lock");
 
-    // Write PID file after acquiring lock
-    let pid_file = pid_path()?;
-    let mut f = File::create(&pid_file)?;
-    writeln!(f, "{}", std::process::id())?;
-    drop(f);
+    // Write daemon info (JSON format with version)
+    let daemon_info = DaemonInfo {
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at: Utc::now(),
+    };
+    write_daemon_info(&daemon_info)?;
 
-    eprintln!("[daemon] Starting sync loop (interval: {}s)", SYNC_INTERVAL_SECS);
+    eprintln!(
+        "[daemon] Starting sync loop (sync: {}s, version check: {}s)",
+        SYNC_INTERVAL_SECS, VERSION_CHECK_INTERVAL_SECS
+    );
 
     // Clean up stale repo entries on startup
     if let Ok(conn) = db::open() {
@@ -130,92 +170,128 @@ pub async fn run_loop() -> Result<()> {
     let repo_states: Arc<Mutex<HashMap<String, RepoSyncState>>> =
         Arc::new(Mutex::new(HashMap::new()));
 
+    // Create intervals for sync and version check
+    let mut sync_interval = tokio::time::interval(Duration::from_secs(SYNC_INTERVAL_SECS));
+    let mut version_interval =
+        tokio::time::interval(Duration::from_secs(VERSION_CHECK_INTERVAL_SECS));
+
+    // Skip the first immediate tick for version check (don't check on startup)
+    version_interval.tick().await;
+
     loop {
-        let conn = db::open()?;
-        let watched = db::list_watched_repos(&conn)?;
-        // list_watched_repos already returns sorted by last_accessed DESC
-
-        if watched.is_empty() {
-            eprintln!("[daemon] No repos to watch, waiting...");
-        } else {
-            let now = Instant::now();
-
-            // Sync repos in parallel with bounded concurrency
-            let results: Vec<(String, SyncResult)> = stream::iter(watched.iter())
-                .map(|repo| {
-                    let states = Arc::clone(&repo_states);
-                    let repo_path = repo.repo.clone();
-                    async move {
-                        // Check if this repo is in backoff
-                        {
-                            let states = states.lock().await;
-                            if let Some(state) = states.get(&repo_path) {
-                                if Instant::now() < state.next_attempt {
-                                    return (repo_path, SyncResult::Skipped);
-                                }
-                            }
-                        }
-
-                        // Sync the repo
-                        match sync_once(&repo_path).await {
-                            Ok(()) => (repo_path, SyncResult::Success),
-                            Err(e) => (repo_path, SyncResult::Error(e)),
-                        }
+        tokio::select! {
+            _ = sync_interval.tick() => {
+                perform_sync_cycle(&repo_states).await;
+            }
+            _ = version_interval.tick() => {
+                match crate::updater::is_binary_updated().await {
+                    Ok(true) => {
+                        eprintln!("[daemon] Binary updated, exiting for restart...");
+                        return Ok(()); // Service manager will restart us
                     }
-                })
-                .buffer_unordered(MAX_CONCURRENT_SYNCS)
-                .collect()
-                .await;
-
-            // Update backoff states based on results
-            let mut synced = 0;
-            let mut skipped = 0;
-            {
-                let mut states = repo_states.lock().await;
-                for (repo_path, result) in results {
-                    match result {
-                        SyncResult::Success => {
-                            states.remove(&repo_path);
-                            synced += 1;
-                        }
-                        SyncResult::Skipped => {
-                            skipped += 1;
-                        }
-                        SyncResult::Error(e) => {
-                            eprintln!("[daemon] Sync error for {}: {}", repo_path, e);
-
-                            let state =
-                                states.entry(repo_path.clone()).or_insert(RepoSyncState {
-                                    consecutive_failures: 0,
-                                    next_attempt: now,
-                                });
-                            state.consecutive_failures += 1;
-                            let backoff = calculate_backoff(state.consecutive_failures);
-                            state.next_attempt = now + backoff;
-
-                            eprintln!(
-                                "[daemon] {} in backoff for {:.0}s (failures: {})",
-                                repo_path,
-                                backoff.as_secs_f64(),
-                                state.consecutive_failures
-                            );
-                        }
+                    Ok(false) => {} // Same version, continue
+                    Err(e) => {
+                        eprintln!("[daemon] Version check failed: {} (continuing)", e);
                     }
                 }
             }
+        }
+    }
+}
 
-            if synced > 0 || skipped > 0 {
-                eprintln!(
-                    "[daemon] Cycle complete: {} synced, {} in backoff",
-                    synced, skipped
-                );
+/// Perform a single sync cycle for all watched repos.
+async fn perform_sync_cycle(repo_states: &Arc<Mutex<HashMap<String, RepoSyncState>>>) {
+    let conn = match db::open() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[daemon] Failed to open database: {}", e);
+            return;
+        }
+    };
+
+    let watched = match db::list_watched_repos(&conn) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("[daemon] Failed to list watched repos: {}", e);
+            return;
+        }
+    };
+
+    if watched.is_empty() {
+        eprintln!("[daemon] No repos to watch, waiting...");
+        return;
+    }
+
+    let now = Instant::now();
+
+    // Sync repos in parallel with bounded concurrency
+    let results: Vec<(String, SyncResult)> = stream::iter(watched.iter())
+        .map(|repo| {
+            let states = Arc::clone(repo_states);
+            let repo_path = repo.repo.clone();
+            async move {
+                // Check if this repo is in backoff
+                {
+                    let states = states.lock().await;
+                    if let Some(state) = states.get(&repo_path) {
+                        if Instant::now() < state.next_attempt {
+                            return (repo_path, SyncResult::Skipped);
+                        }
+                    }
+                }
+
+                // Sync the repo
+                match sync_once(&repo_path).await {
+                    Ok(()) => (repo_path, SyncResult::Success),
+                    Err(e) => (repo_path, SyncResult::Error(e)),
+                }
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_SYNCS)
+        .collect()
+        .await;
+
+    // Update backoff states based on results
+    let mut synced = 0;
+    let mut skipped = 0;
+    {
+        let mut states = repo_states.lock().await;
+        for (repo_path, result) in results {
+            match result {
+                SyncResult::Success => {
+                    states.remove(&repo_path);
+                    synced += 1;
+                }
+                SyncResult::Skipped => {
+                    skipped += 1;
+                }
+                SyncResult::Error(e) => {
+                    eprintln!("[daemon] Sync error for {}: {}", repo_path, e);
+
+                    let state = states.entry(repo_path.clone()).or_insert(RepoSyncState {
+                        consecutive_failures: 0,
+                        next_attempt: now,
+                    });
+                    state.consecutive_failures += 1;
+                    let backoff = calculate_backoff(state.consecutive_failures);
+                    state.next_attempt = now + backoff;
+
+                    eprintln!(
+                        "[daemon] {} in backoff for {:.0}s (failures: {})",
+                        repo_path,
+                        backoff.as_secs_f64(),
+                        state.consecutive_failures
+                    );
+                }
             }
         }
+    }
 
-        // Add jitter to sleep interval to prevent synchronized requests
-        let jitter = (rand::random::<f64>() - 0.5) * 0.2; // ±10%
-        let sleep_secs = SYNC_INTERVAL_SECS as f64 * (1.0 + jitter);
-        tokio::time::sleep(Duration::from_secs_f64(sleep_secs)).await;
+    if synced > 0 || skipped > 0 {
+        eprintln!(
+            "[daemon] Cycle complete: {} synced, {} in backoff",
+            synced, skipped
+        );
     }
 }
 
@@ -229,9 +305,13 @@ fn should_do_full_sync(sync_state: &Option<db::SyncState>, has_cursor: bool) -> 
     let now = Utc::now();
 
     // Check if we're in cooldown from a recent attempt (prevents retry storms)
-    let in_cooldown = state.last_full_sync_attempt_at.as_ref()
+    let in_cooldown = state
+        .last_full_sync_attempt_at
+        .as_ref()
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
-        .map(|t| now - t.with_timezone(&Utc) <= ChronoDuration::minutes(FULL_SYNC_RETRY_COOLDOWN_MINS))
+        .map(|t| {
+            now - t.with_timezone(&Utc) <= ChronoDuration::minutes(FULL_SYNC_RETRY_COOLDOWN_MINS)
+        })
         .unwrap_or(false);
 
     if in_cooldown {
@@ -244,7 +324,9 @@ fn should_do_full_sync(sync_state: &Option<db::SyncState>, has_cursor: bool) -> 
     }
 
     // Check if successful full sync is stale (> 1 hour)
-    let needs_full = state.last_full_sync_at.as_ref()
+    let needs_full = state
+        .last_full_sync_at
+        .as_ref()
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
         .map(|t| now - t.with_timezone(&Utc) > ChronoDuration::hours(FULL_SYNC_INTERVAL_HOURS))
         .unwrap_or(true); // Never successfully completed
@@ -322,7 +404,10 @@ async fn sync_once(repo_path: &str) -> Result<()> {
     // Note: pending_ops are keyed by forge_repo for consistency
     let pending_ops = db::load_pending_ops(&conn, &link.forge_repo)?;
     if !pending_ops.is_empty() {
-        eprintln!("[daemon] Processing {} pending operations...", pending_ops.len());
+        eprintln!(
+            "[daemon] Processing {} pending operations...",
+            pending_ops.len()
+        );
         let synced = process_pending_ops(forge.as_ref(), &repo, &conn, &pending_ops).await;
         if synced > 0 {
             eprintln!("[daemon] Synced {} pending operations", synced);
@@ -332,7 +417,8 @@ async fn sync_once(repo_path: &str) -> Result<()> {
     // === ISSUES ===
     // Calculate cursor for incremental sync (subtract 1 second for safety buffer)
     let sync_state = db::get_sync_state(&conn, &link.forge_repo)?;
-    let issues_cursor = sync_state.as_ref()
+    let issues_cursor = sync_state
+        .as_ref()
         .and_then(|s| s.issues_last_sync.as_ref())
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
         .map(|t| t.with_timezone(&Utc) - ChronoDuration::seconds(1));
@@ -383,7 +469,8 @@ async fn sync_once(repo_path: &str) -> Result<()> {
     )?;
 
     // === COMMENTS ===
-    let comments_cursor = sync_state.as_ref()
+    let comments_cursor = sync_state
+        .as_ref()
         .and_then(|s| s.comments_last_sync.as_ref())
         .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
         .map(|t| t.with_timezone(&Utc) - ChronoDuration::seconds(1));
@@ -451,7 +538,11 @@ async fn sync_once(repo_path: &str) -> Result<()> {
 
     eprintln!(
         "[daemon] {} sync for {}: {} issues (+{} -{} ~{}), {} comments (+{} -{} ~{})",
-        if needs_full_sync { "Full" } else { "Incremental" },
+        if needs_full_sync {
+            "Full"
+        } else {
+            "Incremental"
+        },
         link.forge_repo,
         issues.len(),
         issues_stats.inserted,
@@ -493,7 +584,9 @@ async fn process_pending_ops(
                     // Conflict or resource not found - server wins, discard operation
                     eprintln!(
                         "[daemon] Conflict for {} op on {}: {} (discarding)",
-                        op.op_type, repo.full_name(), e
+                        op.op_type,
+                        repo.full_name(),
+                        e
                     );
                     if let Err(e) = db::complete_op(conn, op.id) {
                         eprintln!("[daemon] Failed to discard op {}: {}", op.id, e);
@@ -501,10 +594,7 @@ async fn process_pending_ops(
                     synced += 1; // Count as processed
                 } else {
                     // Network or other transient error - leave in queue for retry
-                    eprintln!(
-                        "[daemon] Failed {} op, will retry: {}",
-                        op.op_type, e
-                    );
+                    eprintln!("[daemon] Failed {} op, will retry: {}", op.op_type, e);
                 }
             }
         }
@@ -514,11 +604,7 @@ async fn process_pending_ops(
 }
 
 /// Execute a single pending operation
-async fn execute_pending_op(
-    forge: &dyn Forge,
-    repo: &Repo,
-    op: &db::PendingOp,
-) -> Result<()> {
+async fn execute_pending_op(forge: &dyn Forge, repo: &Repo, op: &db::PendingOp) -> Result<()> {
     let payload: serde_json::Value = serde_json::from_str(&op.payload)?;
 
     match op.op_type.as_str() {
@@ -543,7 +629,8 @@ async fn execute_pending_op(
         }
         "comment" => {
             // Support both old issue_number and new issue_id keys
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -553,7 +640,8 @@ async fn execute_pending_op(
             eprintln!("[daemon] Added comment to {}", issue_display);
         }
         "close" => {
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -562,7 +650,8 @@ async fn execute_pending_op(
             eprintln!("[daemon] Closed {}", issue_display);
         }
         "reopen" => {
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -571,7 +660,8 @@ async fn execute_pending_op(
             eprintln!("[daemon] Reopened {}", issue_display);
         }
         "label_add" => {
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -581,7 +671,8 @@ async fn execute_pending_op(
             eprintln!("[daemon] Added label '{}' to {}", label, issue_display);
         }
         "label_remove" => {
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -591,7 +682,8 @@ async fn execute_pending_op(
             eprintln!("[daemon] Removed label '{}' from {}", label, issue_display);
         }
         "assign" => {
-            let issue_id = payload["issue_id"].as_str()
+            let issue_id = payload["issue_id"]
+                .as_str()
                 .map(|s| s.to_string())
                 .or_else(|| payload["issue_number"].as_u64().map(|n| n.to_string()))
                 .unwrap_or_default();
@@ -633,12 +725,21 @@ mod tests {
         let b3 = calculate_backoff(3);
 
         // With ±25% jitter: 1 failure = 22.5-37.5s, 2 = 45-75s, 3 = 90-150s
-        assert!(b1.as_secs_f64() >= 22.5 && b1.as_secs_f64() <= 37.5,
-            "1 failure backoff {} out of range", b1.as_secs_f64());
-        assert!(b2.as_secs_f64() >= 45.0 && b2.as_secs_f64() <= 75.0,
-            "2 failure backoff {} out of range", b2.as_secs_f64());
-        assert!(b3.as_secs_f64() >= 90.0 && b3.as_secs_f64() <= 150.0,
-            "3 failure backoff {} out of range", b3.as_secs_f64());
+        assert!(
+            b1.as_secs_f64() >= 22.5 && b1.as_secs_f64() <= 37.5,
+            "1 failure backoff {} out of range",
+            b1.as_secs_f64()
+        );
+        assert!(
+            b2.as_secs_f64() >= 45.0 && b2.as_secs_f64() <= 75.0,
+            "2 failure backoff {} out of range",
+            b2.as_secs_f64()
+        );
+        assert!(
+            b3.as_secs_f64() >= 90.0 && b3.as_secs_f64() <= 150.0,
+            "3 failure backoff {} out of range",
+            b3.as_secs_f64()
+        );
     }
 
     #[test]
@@ -659,8 +760,11 @@ mod tests {
         let secs = backoff.as_secs_f64();
 
         // Should be capped at 960s with ±25% jitter = 720 to 1200
-        assert!(secs >= 720.0 && secs <= 1200.0,
-            "extreme failure backoff {} should be capped", secs);
+        assert!(
+            secs >= 720.0 && secs <= 1200.0,
+            "extreme failure backoff {} should be capped",
+            secs
+        );
     }
 
     #[test]
@@ -694,10 +798,7 @@ mod tests {
             .collect();
 
         let start = Instant::now();
-        let results: Vec<_> = stream::iter(tasks)
-            .buffer_unordered(4)
-            .collect()
-            .await;
+        let results: Vec<_> = stream::iter(tasks).buffer_unordered(4).collect().await;
         let elapsed = start.elapsed();
 
         assert_eq!(results.len(), 4);

--- a/src/db/comments.rs
+++ b/src/db/comments.rs
@@ -1,7 +1,7 @@
 //! Comment storage and retrieval
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 use std::collections::HashMap;
 
 use super::SyncResult;
@@ -158,11 +158,7 @@ pub fn save_comments(
 }
 
 /// Load comments for a specific issue (excludes deleted comments)
-pub fn load_comments(
-    conn: &Connection,
-    forge_repo: &str,
-    issue_id: &str,
-) -> Result<Vec<Comment>> {
+pub fn load_comments(conn: &Connection, forge_repo: &str, issue_id: &str) -> Result<Vec<Comment>> {
     let mut stmt = conn.prepare(
         "SELECT comment_id, issue_id, body, author, created_at, updated_at
          FROM comments WHERE forge_repo = ? AND issue_id = ? AND deleted = 0

--- a/src/db/goals.rs
+++ b/src/db/goals.rs
@@ -1,7 +1,7 @@
 //! Goal/milestone storage and retrieval
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::forges::{Goal, GoalState};
 
@@ -10,7 +10,10 @@ pub fn save_goals(conn: &Connection, forge_repo: &str, goals: &[Goal]) -> Result
     let tx = conn.unchecked_transaction()?;
 
     // Delete existing goals for this repo
-    tx.execute("DELETE FROM goals WHERE forge_repo = ?", params![forge_repo])?;
+    tx.execute(
+        "DELETE FROM goals WHERE forge_repo = ?",
+        params![forge_repo],
+    )?;
 
     // Insert new goals
     let mut stmt = tx.prepare(
@@ -119,11 +122,7 @@ pub fn load_goals(conn: &Connection, forge_repo: &str, state: Option<&str>) -> R
 }
 
 /// Load a single goal by name or ID
-pub fn load_goal_by_name(
-    conn: &Connection,
-    forge_repo: &str,
-    name: &str,
-) -> Result<Option<Goal>> {
+pub fn load_goal_by_name(conn: &Connection, forge_repo: &str, name: &str) -> Result<Option<Goal>> {
     let mut stmt = conn.prepare(
         "SELECT goal_id, name, description, target_date, state, progress, open_count, closed_count, created_at, updated_at, html_url
          FROM goals WHERE forge_repo = ? AND (name = ? OR goal_id = ?)",

--- a/src/db/issues.rs
+++ b/src/db/issues.rs
@@ -1,7 +1,7 @@
 //! Issue CRUD operations
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::forges::{Issue, Label};
 
@@ -148,10 +148,7 @@ pub fn save_issues(
         // Batch insert seen IDs (500 at a time to avoid SQL length limits)
         for chunk in issues.chunks(500) {
             let placeholders: String = chunk.iter().map(|_| "(?)").collect::<Vec<_>>().join(",");
-            let sql = format!(
-                "INSERT INTO seen_issues (issue_id) VALUES {}",
-                placeholders
-            );
+            let sql = format!("INSERT INTO seen_issues (issue_id) VALUES {}", placeholders);
             let params: Vec<&str> = chunk.iter().map(|i| i.id.as_str()).collect();
             tx.execute(&sql, rusqlite::params_from_iter(params))?;
         }
@@ -204,7 +201,14 @@ pub fn save_issues(
                     issues_last_sync = COALESCE(?4, issues_last_sync),
                     last_full_sync_at = ?5,
                     last_full_sync_attempt_at = ?6",
-                params![repo, now, issue_count, max_updated_at, full_sync_cursor, now],
+                params![
+                    repo,
+                    now,
+                    issue_count,
+                    max_updated_at,
+                    full_sync_cursor,
+                    now
+                ],
             )?;
         } else {
             // Full sync incomplete: only update last_full_sync_attempt_at (not last_full_sync_at)
@@ -336,8 +340,7 @@ pub fn load_issues_filtered(
             let labels_json: String = row.get(5)?;
             let labels = parse_labels_json(&labels_json);
             let assignees_json: String = row.get::<_, Option<String>>(6)?.unwrap_or_default();
-            let assignees: Vec<String> =
-                serde_json::from_str(&assignees_json).unwrap_or_default();
+            let assignees: Vec<String> = serde_json::from_str(&assignees_json).unwrap_or_default();
             let priority: i64 = row.get::<_, Option<i64>>(7)?.unwrap_or(4);
 
             Ok(Issue {
@@ -362,7 +365,11 @@ pub fn load_issues_filtered(
 }
 
 /// Load issues with filter struct (supports all view filter fields)
-pub fn load_issues_with_filter(conn: &Connection, repo: &str, filter: &IssueFilter) -> Result<Vec<Issue>> {
+pub fn load_issues_with_filter(
+    conn: &Connection,
+    repo: &str,
+    filter: &IssueFilter,
+) -> Result<Vec<Issue>> {
     let mut sql = String::from(
         "SELECT issue_id, title, body, state, author, labels, assignees, priority, priority_label, created_at, updated_at, html_url, milestone
          FROM issues WHERE repo = ? AND deleted = 0",
@@ -402,7 +409,8 @@ pub fn load_issues_with_filter(conn: &Connection, repo: &str, filter: &IssueFilt
     // Filter by any of these labels (OR)
     if let Some(labels) = filter.label_any {
         if !labels.is_empty() {
-            let conditions: Vec<String> = labels.iter().map(|_| "labels LIKE ?".to_string()).collect();
+            let conditions: Vec<String> =
+                labels.iter().map(|_| "labels LIKE ?".to_string()).collect();
             sql.push_str(&format!(" AND ({})", conditions.join(" OR ")));
             for label in labels {
                 params_vec.push(Box::new(format!("%\"{}\"%", label)));
@@ -444,24 +452,36 @@ pub fn load_issues_with_filter(conn: &Connection, repo: &str, filter: &IssueFilt
     // Date filters - parse human-readable durations like "30 days", "2 weeks"
     if let Some(duration) = filter.updated_before {
         if let Some(modifier) = parse_duration_to_sqlite_modifier(duration) {
-            sql.push_str(&format!(" AND updated_at < datetime('now', '{}')", modifier));
+            sql.push_str(&format!(
+                " AND updated_at < datetime('now', '{}')",
+                modifier
+            ));
         }
     }
     if let Some(duration) = filter.updated_after {
         if let Some(modifier) = parse_duration_to_sqlite_modifier(duration) {
-            sql.push_str(&format!(" AND updated_at >= datetime('now', '{}')", modifier));
+            sql.push_str(&format!(
+                " AND updated_at >= datetime('now', '{}')",
+                modifier
+            ));
         }
     }
 
     // Created date filters
     if let Some(duration) = filter.created_before {
         if let Some(modifier) = parse_duration_to_sqlite_modifier(duration) {
-            sql.push_str(&format!(" AND created_at < datetime('now', '{}')", modifier));
+            sql.push_str(&format!(
+                " AND created_at < datetime('now', '{}')",
+                modifier
+            ));
         }
     }
     if let Some(duration) = filter.created_after {
         if let Some(modifier) = parse_duration_to_sqlite_modifier(duration) {
-            sql.push_str(&format!(" AND created_at >= datetime('now', '{}')", modifier));
+            sql.push_str(&format!(
+                " AND created_at >= datetime('now', '{}')",
+                modifier
+            ));
         }
     }
 
@@ -483,8 +503,7 @@ pub fn load_issues_with_filter(conn: &Connection, repo: &str, filter: &IssueFilt
             let labels_json: String = row.get(5)?;
             let labels = parse_labels_json(&labels_json);
             let assignees_json: String = row.get::<_, Option<String>>(6)?.unwrap_or_default();
-            let assignees: Vec<String> =
-                serde_json::from_str(&assignees_json).unwrap_or_default();
+            let assignees: Vec<String> = serde_json::from_str(&assignees_json).unwrap_or_default();
             let priority: i64 = row.get::<_, Option<i64>>(7)?.unwrap_or(4);
 
             Ok(Issue {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -18,36 +18,36 @@ use std::path::PathBuf;
 // Re-export public types and functions
 
 // From comments
-pub use comments::{count_comments_by_issue, load_comments, save_comments, Comment};
+pub use comments::{Comment, count_comments_by_issue, load_comments, save_comments};
 
 // From goals
 pub use goals::{count_goals, load_goal_by_name, load_goals, save_goal, save_goals};
 
 // From issues
-pub use issues::{load_issue, load_issues_with_filter, save_issues, IssueFilter};
+pub use issues::{IssueFilter, load_issue, load_issues_with_filter, save_issues};
 #[cfg(test)]
 pub use issues::{load_issues, load_issues_filtered};
 
 // From rate_limit
+#[allow(unused_imports)]
+pub use rate_limit::RateLimitState;
 pub use rate_limit::{
     get_rate_limit_state, is_rate_limited, set_rate_limit_state, update_rate_limit_budget,
 };
-#[allow(unused_imports)]
-pub use rate_limit::RateLimitState;
 
 // From repos
-pub use repos::{
-    add_watched_repo, cleanup_stale_repos, clear_worktree_issues, get_repo_link,
-    get_worktree_issue, list_watched_repos, remove_repo_link, remove_watched_repo, set_repo_link,
-    set_worktree_issue, touch_repo, RepoLink,
-};
 #[allow(unused_imports)]
 pub use repos::WatchedRepo;
+pub use repos::{
+    RepoLink, add_watched_repo, cleanup_stale_repos, clear_worktree_issues, get_repo_link,
+    get_worktree_issue, list_watched_repos, remove_repo_link, remove_watched_repo, set_repo_link,
+    set_worktree_issue, touch_repo,
+};
 
 // From sync_state
 pub use sync_state::{
-    complete_op, count_pending_ops, get_sync_state, load_pending_ops, purge_deleted_items,
-    queue_op, PendingOp, SyncState,
+    PendingOp, SyncState, complete_op, count_pending_ops, get_sync_state, load_pending_ops,
+    purge_deleted_items, queue_op,
 };
 
 /// Result of a sync operation with insert/update/delete counts

--- a/src/db/rate_limit.rs
+++ b/src/db/rate_limit.rs
@@ -1,7 +1,7 @@
 //! Rate limit state tracking for forge APIs
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 /// Rate limit state for a forge
 #[derive(Debug, Clone)]

--- a/src/db/repos.rs
+++ b/src/db/repos.rs
@@ -1,7 +1,7 @@
 //! Repository management - watched repos, repo links, and worktree issues
 
 use anyhow::Result;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 // ============================================================================
 // Watched Repos
@@ -187,9 +187,8 @@ pub fn set_worktree_issue(
 ///
 /// Returns (repo, issue_id) if an association exists.
 pub fn get_worktree_issue(conn: &Connection, git_dir: &str) -> Result<Option<(String, String)>> {
-    let mut stmt = conn.prepare(
-        "SELECT repo, issue_id FROM worktree_issues WHERE git_dir = ? LIMIT 1",
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT repo, issue_id FROM worktree_issues WHERE git_dir = ? LIMIT 1")?;
 
     let result = stmt
         .query_row(params![git_dir], |row| {
@@ -471,13 +470,21 @@ mod tests {
         set_worktree_issue(&conn, "/path/to/.git", "owner/repo", "123").unwrap();
 
         // Verify it exists
-        assert!(get_worktree_issue(&conn, "/path/to/.git").unwrap().is_some());
+        assert!(
+            get_worktree_issue(&conn, "/path/to/.git")
+                .unwrap()
+                .is_some()
+        );
 
         // Clear it
         clear_worktree_issues(&conn, "/path/to/.git").unwrap();
 
         // Verify it's gone
-        assert!(get_worktree_issue(&conn, "/path/to/.git").unwrap().is_none());
+        assert!(
+            get_worktree_issue(&conn, "/path/to/.git")
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -150,30 +150,21 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     // Migration: add html_url column to issues if it doesn't exist
-    let has_html_url: bool = conn
-        .prepare("SELECT html_url FROM issues LIMIT 0")
-        .is_ok();
+    let has_html_url: bool = conn.prepare("SELECT html_url FROM issues LIMIT 0").is_ok();
     if !has_html_url {
         conn.execute("ALTER TABLE issues ADD COLUMN html_url TEXT", [])?;
     }
 
     // Migration: add milestone column to issues if it doesn't exist
-    let has_milestone: bool = conn
-        .prepare("SELECT milestone FROM issues LIMIT 0")
-        .is_ok();
+    let has_milestone: bool = conn.prepare("SELECT milestone FROM issues LIMIT 0").is_ok();
     if !has_milestone {
         conn.execute("ALTER TABLE issues ADD COLUMN milestone TEXT", [])?;
     }
 
     // Migration: add progress column to goals if it doesn't exist
-    let has_progress: bool = conn
-        .prepare("SELECT progress FROM goals LIMIT 0")
-        .is_ok();
+    let has_progress: bool = conn.prepare("SELECT progress FROM goals LIMIT 0").is_ok();
     if !has_progress {
-        conn.execute(
-            "ALTER TABLE goals ADD COLUMN progress REAL DEFAULT 0.0",
-            [],
-        )?;
+        conn.execute("ALTER TABLE goals ADD COLUMN progress REAL DEFAULT 0.0", [])?;
     }
 
     // Migration: add rate_limit and remaining columns to rate_limit_state if they don't exist
@@ -225,9 +216,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     // Migration: add assignees column to issues if it doesn't exist
-    let has_assignees: bool = conn
-        .prepare("SELECT assignees FROM issues LIMIT 0")
-        .is_ok();
+    let has_assignees: bool = conn.prepare("SELECT assignees FROM issues LIMIT 0").is_ok();
     if !has_assignees {
         conn.execute(
             "ALTER TABLE issues ADD COLUMN assignees TEXT NOT NULL DEFAULT '[]'",
@@ -236,9 +225,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     // Migration: add priority column to issues if it doesn't exist
-    let has_priority: bool = conn
-        .prepare("SELECT priority FROM issues LIMIT 0")
-        .is_ok();
+    let has_priority: bool = conn.prepare("SELECT priority FROM issues LIMIT 0").is_ok();
     if !has_priority {
         conn.execute(
             "ALTER TABLE issues ADD COLUMN priority INTEGER NOT NULL DEFAULT 4",
@@ -283,10 +270,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         .prepare("SELECT goals_last_sync FROM sync_state LIMIT 0")
         .is_ok();
     if !has_goals_last_sync {
-        conn.execute(
-            "ALTER TABLE sync_state ADD COLUMN goals_last_sync TEXT",
-            [],
-        )?;
+        conn.execute("ALTER TABLE sync_state ADD COLUMN goals_last_sync TEXT", [])?;
     }
 
     let has_last_full_sync_at: bool = conn
@@ -310,9 +294,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
     }
 
     // Migration: add soft-delete columns to issues
-    let has_issues_deleted: bool = conn
-        .prepare("SELECT deleted FROM issues LIMIT 0")
-        .is_ok();
+    let has_issues_deleted: bool = conn.prepare("SELECT deleted FROM issues LIMIT 0").is_ok();
     if !has_issues_deleted {
         conn.execute(
             "ALTER TABLE issues ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",
@@ -386,9 +368,7 @@ fn run_migrations(conn: &Connection) -> Result<()> {
         conn.execute("ALTER TABLE comments ADD COLUMN updated_at TEXT", [])?;
     }
 
-    let has_comments_deleted: bool = conn
-        .prepare("SELECT deleted FROM comments LIMIT 0")
-        .is_ok();
+    let has_comments_deleted: bool = conn.prepare("SELECT deleted FROM comments LIMIT 0").is_ok();
     if !has_comments_deleted {
         conn.execute(
             "ALTER TABLE comments ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0",

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -1,7 +1,7 @@
 //! Sync state and pending operations management
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 /// Sync state for a repository with per-type cursors
 #[derive(Debug, Clone, Default)]

--- a/src/display.rs
+++ b/src/display.rs
@@ -10,7 +10,7 @@ use std::io::IsTerminal;
 
 use chrono::{DateTime, Datelike, Utc};
 use colored::{ColoredString, Colorize};
-use textwrap::{wrap, Options};
+use textwrap::{Options, wrap};
 
 use crate::db::Comment;
 use crate::forges::{Goal, GoalState, Issue, Label};
@@ -161,7 +161,10 @@ fn format_labels(labels: &[Label], tty: bool) -> String {
 
     if tty && supports_truecolor() {
         // Render each label with its color
-        let rendered: Vec<String> = labels.iter().map(|l| render_label(l, tty).to_string()).collect();
+        let rendered: Vec<String> = labels
+            .iter()
+            .map(|l| render_label(l, tty).to_string())
+            .collect();
         format!(" {}", rendered.join(" "))
     } else if tty {
         // Fallback: all labels in yellow brackets
@@ -260,7 +263,11 @@ pub fn format_issue(issue: &Issue, comments: &[Comment]) -> String {
     // URL line (in header, not footer) - keep https:// for terminal clickability
     if let Some(url) = &issue.url {
         if tty {
-            output.push_str(&format!("  {} {}\n", "↗".dimmed(), url.dimmed().underline()));
+            output.push_str(&format!(
+                "  {} {}\n",
+                "↗".dimmed(),
+                url.dimmed().underline()
+            ));
         } else {
             output.push_str(&format!("  {}\n", url));
         }
@@ -285,7 +292,11 @@ pub fn format_issue(issue: &Issue, comments: &[Comment]) -> String {
             output.push_str(&format!(" {}\n", light_separator));
         }
 
-        let comments_header = format!("  {} comment{}", comments.len(), if comments.len() == 1 { "" } else { "s" });
+        let comments_header = format!(
+            "  {} comment{}",
+            comments.len(),
+            if comments.len() == 1 { "" } else { "s" }
+        );
         if tty {
             output.push_str(&format!("{}\n", comments_header.bold()));
         } else {
@@ -298,7 +309,11 @@ pub fn format_issue(issue: &Issue, comments: &[Comment]) -> String {
             let comment_time = relative_time(&c.created_at);
 
             if tty {
-                output.push_str(&format!("  {} · {}\n", comment_author.cyan(), comment_time.dimmed()));
+                output.push_str(&format!(
+                    "  {} · {}\n",
+                    comment_author.cyan(),
+                    comment_time.dimmed()
+                ));
             } else {
                 output.push_str(&format!("  {} · {}\n", comment_author, comment_time));
             }
@@ -447,10 +462,7 @@ pub fn print_goals(goals: &[Goal]) {
         // Avoid dimmed colors - they're unreadable on light terminals
         println!(
             "{} {:>8}  {}  {}",
-            status_char,
-            progress_str,
-            goal.name,
-            target
+            status_char, progress_str, goal.name, target
         );
     }
 }
@@ -586,12 +598,12 @@ mod tests {
 
     #[test]
     fn test_priority_indicator() {
-        assert_eq!(priority_indicator(0), "[!]");  // Urgent
-        assert_eq!(priority_indicator(1), "▰▰▰");  // High
-        assert_eq!(priority_indicator(2), "▰▰▱");  // Medium
-        assert_eq!(priority_indicator(3), "▰▱▱");  // Low
-        assert_eq!(priority_indicator(4), "---");  // None
-        assert_eq!(priority_indicator(5), "---");  // Unknown defaults to none
+        assert_eq!(priority_indicator(0), "[!]"); // Urgent
+        assert_eq!(priority_indicator(1), "▰▰▰"); // High
+        assert_eq!(priority_indicator(2), "▰▰▱"); // Medium
+        assert_eq!(priority_indicator(3), "▰▱▱"); // Low
+        assert_eq!(priority_indicator(4), "---"); // None
+        assert_eq!(priority_indicator(5), "---"); // Unknown defaults to none
         assert_eq!(priority_indicator(255), "---"); // Edge case
     }
 }

--- a/src/forges/github/client.rs
+++ b/src/forges/github/client.rs
@@ -67,8 +67,10 @@ fn parse_last_page_from_link_header(link_header: &str) -> Option<usize> {
                         if let Some(page_start) = url.find(prefix) {
                             let page_str = &url[page_start + prefix.len()..];
                             // Take digits until non-digit
-                            let page_num: String =
-                                page_str.chars().take_while(|c| c.is_ascii_digit()).collect();
+                            let page_num: String = page_str
+                                .chars()
+                                .take_while(|c| c.is_ascii_digit())
+                                .collect();
                             return page_num.parse().ok();
                         }
                     }
@@ -115,7 +117,9 @@ impl GitHubClient {
         // For incremental sync with since parameter, we can't use search API count
         // because it doesn't support since. Use sequential pagination instead.
         if since.is_some() {
-            return self.list_issues_since_sequential(repo, since.unwrap()).await;
+            return self
+                .list_issues_since_sequential(repo, since.unwrap())
+                .await;
         }
 
         // Get total count from search API
@@ -314,7 +318,7 @@ impl GitHubClient {
                             .into_iter()
                             .filter(|i| i.pull_request.is_none()) // Filter PRs at source
                             .map(|i| i.into_issue())
-                            .collect())
+                            .collect());
                     }
                     Err(e) if attempt < MAX_RETRIES - 1 => {
                         let delay = Duration::from_secs(1 << attempt);
@@ -428,7 +432,9 @@ impl GitHubClient {
         // For incremental sync with since parameter, use sequential pagination
         // (smaller dataset, and we can't easily get total count)
         if since.is_some() {
-            return self.list_comments_since_sequential(repo, since.unwrap()).await;
+            return self
+                .list_comments_since_sequential(repo, since.unwrap())
+                .await;
         }
 
         // Fetch first page to get total page count from Link header
@@ -440,10 +446,7 @@ impl GitHubClient {
             return Ok(FetchResult::complete(first_page_comments));
         }
 
-        eprintln!(
-            "Fetching comments across {} pages...",
-            total_pages
-        );
+        eprintln!("Fetching comments across {} pages...", total_pages);
 
         // Fetch remaining pages (2..=total_pages) in parallel with semaphore-bounded concurrency
         let futures = (2..=total_pages).map(|page| {
@@ -452,7 +455,9 @@ impl GitHubClient {
             async move {
                 // Acquire semaphore permit before making request
                 let _permit = REQUEST_SEMAPHORE.acquire().await.unwrap();
-                client.fetch_comments_page_with_retry(&repo, page, None).await
+                client
+                    .fetch_comments_page_with_retry(&repo, page, None)
+                    .await
             }
         });
 
@@ -477,7 +482,12 @@ impl GitHubClient {
             }
             completed += 1;
             if completed % 10 == 0 || completed == total_pages {
-                eprintln!("  {}/{} pages ({} comments)", completed, total_pages, all_comments.len());
+                eprintln!(
+                    "  {}/{} pages ({} comments)",
+                    completed,
+                    total_pages,
+                    all_comments.len()
+                );
             }
         }
 
@@ -491,7 +501,10 @@ impl GitHubClient {
             };
             eprintln!(
                 "Warning: {} of {} pages failed ({}), got {} comments",
-                error_count, total_pages, reason, all_comments.len()
+                error_count,
+                total_pages,
+                reason,
+                all_comments.len()
             );
         }
 
@@ -512,7 +525,10 @@ impl GitHubClient {
 
         loop {
             let _permit = REQUEST_SEMAPHORE.acquire().await.unwrap();
-            match self.fetch_comments_page_with_retry(repo, page, Some(&since)).await {
+            match self
+                .fetch_comments_page_with_retry(repo, page, Some(&since))
+                .await
+            {
                 Ok(comments) => {
                     let count = comments.len();
                     all_comments.extend(comments);
@@ -596,10 +612,7 @@ impl GitHubClient {
             let body = response.text().await?;
 
             if is_rate_limited(status, &body) && attempt < MAX_RETRIES - 1 {
-                eprintln!(
-                    "Rate limited on comments page 1, retrying in {:?}",
-                    delay
-                );
+                eprintln!("Rate limited on comments page 1, retrying in {:?}", delay);
                 tokio::time::sleep(delay).await;
                 continue;
             }
@@ -1211,7 +1224,8 @@ mod tests {
 
     #[test]
     fn test_parse_link_header_large_page_number() {
-        let header = r#"<https://api.github.com/repos/foo/bar/issues/comments?page=9999>; rel="last""#;
+        let header =
+            r#"<https://api.github.com/repos/foo/bar/issues/comments?page=9999>; rel="last""#;
         assert_eq!(parse_last_page_from_link_header(header), Some(9999));
     }
 

--- a/src/forges/github/mod.rs
+++ b/src/forges/github/mod.rs
@@ -12,8 +12,8 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::forges::{
-    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal,
-    Issue, Label, LinkArgs, LinkResult, RateLimitInfo,
+    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, Issue,
+    Label, LinkArgs, LinkResult, RateLimitInfo,
 };
 use crate::repo::Repo;
 use crate::{config, db, repo};
@@ -35,8 +35,7 @@ pub const AUTH: AuthConfig = AuthConfig {
 };
 
 /// Default [on_start] config for GitHub repos
-pub const DEFAULT_ON_START_TOML: &str =
-    "add_labels = [\"in progress\"]\nassign_self = true\n";
+pub const DEFAULT_ON_START_TOML: &str = "add_labels = [\"in progress\"]\nassign_self = true\n";
 
 /// Default [on_cleanup] config for GitHub repos
 pub const DEFAULT_ON_CLEANUP_TOML: &str = "remove_labels = [\"in progress\"]\n";
@@ -222,39 +221,49 @@ impl Forge for GitHubClient {
     }
 
     async fn create_comment(&self, repo: &Repo, issue_id: &str, body: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.create_comment(repo, issue_number, body).await
     }
 
     async fn close_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
-        self.patch_issue(repo, issue_number, &serde_json::json!({ "state": "closed" }))
-            .await
+        self.patch_issue(
+            repo,
+            issue_number,
+            &serde_json::json!({ "state": "closed" }),
+        )
+        .await
     }
 
     async fn reopen_issue(&self, repo: &Repo, issue_id: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.patch_issue(repo, issue_number, &serde_json::json!({ "state": "open" }))
             .await
     }
 
     async fn add_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.add_label(repo, issue_number, label).await
     }
 
     async fn remove_label(&self, repo: &Repo, issue_id: &str, label: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.remove_label(repo, issue_number, label).await
     }
 
     async fn assign_issue(&self, repo: &Repo, issue_id: &str, assignee: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         self.assign_issue(repo, issue_number, assignee).await
     }
@@ -331,7 +340,8 @@ impl Forge for GitHubClient {
     }
 
     async fn assign_to_goal(&self, repo: &Repo, issue_id: &str, goal_id: &str) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
         let milestone_number: u64 = goal_id
             .parse()
@@ -351,7 +361,8 @@ impl Forge for GitHubClient {
         config: &toml::Value,
         username: Option<&str>,
     ) -> Result<()> {
-        let issue_number: u64 = issue_id.parse()
+        let issue_number: u64 = issue_id
+            .parse()
             .map_err(|_| anyhow::anyhow!("Invalid issue number: {}", issue_id))?;
 
         // Parse GitHub-specific config from opaque toml::Value
@@ -387,10 +398,9 @@ impl Forge for GitHubClient {
     }
 
     fn validate_on_start_config(&self, config: &toml::Value) -> Result<()> {
-        let _: GitHubOnStartConfig = config
-            .clone()
-            .try_into()
-            .context("Invalid [on_start] config for GitHub.\nValid fields: add_labels, assign_self")?;
+        let _: GitHubOnStartConfig = config.clone().try_into().context(
+            "Invalid [on_start] config for GitHub.\nValid fields: add_labels, assign_self",
+        )?;
         Ok(())
     }
 

--- a/src/forges/github/oauth.rs
+++ b/src/forges/github/oauth.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde::Deserialize;
 
 use super::client::create_http_client;
@@ -39,10 +39,7 @@ pub async fn oauth_flow() -> Result<TokenResponse> {
     let client = create_http_client();
 
     // Step 1: Request device code
-    let params = [
-        ("client_id", GITHUB_CLIENT_ID),
-        ("scope", "repo read:user"),
-    ];
+    let params = [("client_id", GITHUB_CLIENT_ID), ("scope", "repo read:user")];
 
     let response = client
         .post(GITHUB_DEVICE_CODE_URL)
@@ -52,8 +49,13 @@ pub async fn oauth_flow() -> Result<TokenResponse> {
         .await?;
 
     let body = response.text().await?;
-    let device: DeviceCodeResponse = serde_json::from_str(&body)
-        .map_err(|e| anyhow!("Failed to parse device code response: {}\nBody: {}", e, body))?;
+    let device: DeviceCodeResponse = serde_json::from_str(&body).map_err(|e| {
+        anyhow!(
+            "Failed to parse device code response: {}\nBody: {}",
+            e,
+            body
+        )
+    })?;
 
     // Step 2: Show code to user and open browser
     println!();

--- a/src/forges/jira/adf.rs
+++ b/src/forges/jira/adf.rs
@@ -24,7 +24,11 @@ fn convert_adf_node(node: &serde_json::Value, output: &mut String, depth: usize)
             output.push_str("\n\n");
         }
         "heading" => {
-            let level = node.get("attrs").and_then(|a| a.get("level")).and_then(|l| l.as_u64()).unwrap_or(1);
+            let level = node
+                .get("attrs")
+                .and_then(|a| a.get("level"))
+                .and_then(|l| l.as_u64())
+                .unwrap_or(1);
             output.push_str(&"#".repeat(level as usize));
             output.push(' ');
             if let Some(content) = node.get("content").and_then(|c| c.as_array()) {
@@ -45,12 +49,28 @@ fn convert_adf_node(node: &serde_json::Value, output: &mut String, depth: usize)
                 for mark in marks {
                     let mark_type = mark.get("type").and_then(|t| t.as_str()).unwrap_or("");
                     match mark_type {
-                        "strong" => { prefix.push_str("**"); suffix.insert_str(0, "**"); }
-                        "em" => { prefix.push('*'); suffix.insert(0, '*'); }
-                        "code" => { prefix.push('`'); suffix.insert(0, '`'); }
-                        "strike" => { prefix.push_str("~~"); suffix.insert_str(0, "~~"); }
+                        "strong" => {
+                            prefix.push_str("**");
+                            suffix.insert_str(0, "**");
+                        }
+                        "em" => {
+                            prefix.push('*');
+                            suffix.insert(0, '*');
+                        }
+                        "code" => {
+                            prefix.push('`');
+                            suffix.insert(0, '`');
+                        }
+                        "strike" => {
+                            prefix.push_str("~~");
+                            suffix.insert_str(0, "~~");
+                        }
                         "link" => {
-                            if let Some(href) = mark.get("attrs").and_then(|a| a.get("href")).and_then(|h| h.as_str()) {
+                            if let Some(href) = mark
+                                .get("attrs")
+                                .and_then(|a| a.get("href"))
+                                .and_then(|h| h.as_str())
+                            {
                                 prefix.push('[');
                                 suffix = format!("]({}){}", href, suffix);
                             }
@@ -96,7 +116,11 @@ fn convert_adf_node(node: &serde_json::Value, output: &mut String, depth: usize)
             }
         }
         "codeBlock" => {
-            let language = node.get("attrs").and_then(|a| a.get("language")).and_then(|l| l.as_str()).unwrap_or("");
+            let language = node
+                .get("attrs")
+                .and_then(|a| a.get("language"))
+                .and_then(|l| l.as_str())
+                .unwrap_or("");
             output.push_str("```");
             output.push_str(language);
             output.push('\n');
@@ -121,7 +145,11 @@ fn convert_adf_node(node: &serde_json::Value, output: &mut String, depth: usize)
             output.push_str("---\n\n");
         }
         "mention" => {
-            let text = node.get("attrs").and_then(|a| a.get("text")).and_then(|t| t.as_str()).unwrap_or("@user");
+            let text = node
+                .get("attrs")
+                .and_then(|a| a.get("text"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("@user");
             output.push_str(&format!("[{}]", text));
         }
         "mediaGroup" | "mediaSingle" => {
@@ -132,14 +160,29 @@ fn convert_adf_node(node: &serde_json::Value, output: &mut String, depth: usize)
             }
         }
         "media" => {
-            let media_type = node.get("attrs").and_then(|a| a.get("type")).and_then(|t| t.as_str()).unwrap_or("file");
-            let name = node.get("attrs").and_then(|a| a.get("alt")).and_then(|t| t.as_str())
-                .or_else(|| node.get("attrs").and_then(|a| a.get("id")).and_then(|t| t.as_str()))
+            let media_type = node
+                .get("attrs")
+                .and_then(|a| a.get("type"))
+                .and_then(|t| t.as_str())
+                .unwrap_or("file");
+            let name = node
+                .get("attrs")
+                .and_then(|a| a.get("alt"))
+                .and_then(|t| t.as_str())
+                .or_else(|| {
+                    node.get("attrs")
+                        .and_then(|a| a.get("id"))
+                        .and_then(|t| t.as_str())
+                })
                 .unwrap_or("attachment");
             output.push_str(&format!("[{}: {}]", media_type.to_uppercase(), name));
         }
         "emoji" => {
-            let shortname = node.get("attrs").and_then(|a| a.get("shortName")).and_then(|t| t.as_str()).unwrap_or(":emoji:");
+            let shortname = node
+                .get("attrs")
+                .and_then(|a| a.get("shortName"))
+                .and_then(|t| t.as_str())
+                .unwrap_or(":emoji:");
             output.push_str(shortname);
         }
         "table" => {

--- a/src/forges/jira/client.rs
+++ b/src/forges/jira/client.rs
@@ -2,15 +2,15 @@
 
 use std::sync::RwLock;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use base64::Engine;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::adf::{adf_to_markdown, markdown_to_adf};
-use super::oauth::{refresh_token, JiraAuthMode, JiraCredentials};
+use super::oauth::{JiraAuthMode, JiraCredentials, refresh_token};
 use super::types::*;
-use super::{map_jira_priority, parse_jira_error, truncate, AUTH};
+use super::{AUTH, map_jira_priority, parse_jira_error, truncate};
 use crate::db;
 use crate::forges::{FetchResult, Goal, GoalState, Issue, Label};
 use crate::repo::Repo;
@@ -46,9 +46,7 @@ impl JiraClient {
     fn auth_header(&self) -> (String, String) {
         let creds = self.creds.read().unwrap();
         match &creds.auth_mode {
-            JiraAuthMode::OAuth { .. } => {
-                ("Bearer".to_string(), creds.access_token.clone())
-            }
+            JiraAuthMode::OAuth { .. } => ("Bearer".to_string(), creds.access_token.clone()),
             JiraAuthMode::ApiToken { email } => {
                 // Basic auth: base64(email:token)
                 let basic = base64::engine::general_purpose::STANDARD
@@ -70,7 +68,12 @@ impl JiraClient {
         let url = format!("{}{}", self.api_base(), path);
         let (auth_type, auth_value) = self.auth_header();
 
-        let response = self.client.get(&url).header("Authorization", format!("{} {}", auth_type, auth_value)).send().await?;
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("{} {}", auth_type, auth_value))
+            .send()
+            .await?;
 
         if response.status() == reqwest::StatusCode::UNAUTHORIZED {
             return Err(anyhow!(
@@ -210,9 +213,9 @@ impl JiraClient {
 
         let new_tokens = refresh_token(&stored_refresh_token).await?;
 
-        let expires_at = new_tokens.expires_in.map(|secs| {
-            chrono::Utc::now().timestamp() + secs as i64
-        });
+        let expires_at = new_tokens
+            .expires_in
+            .map(|secs| chrono::Utc::now().timestamp() + secs as i64);
 
         // Update stored credentials
         {
@@ -234,11 +237,7 @@ impl JiraClient {
                 "site_url": creds.site_url,
                 "expires_at": creds.expires_at
             });
-            AUTH.store_credential(
-                &cred_json.to_string(),
-                None,
-                None,
-            )?;
+            AUTH.store_credential(&cred_json.to_string(), None, None)?;
         }
 
         Ok(())
@@ -262,7 +261,10 @@ impl JiraClient {
 
     /// Check if user has write permissions using /mypermissions endpoint
     pub async fn check_write_permission(&self, project_key: &str) -> Result<bool> {
-        let path = format!("/mypermissions?projectKey={}&permissions=CREATE_ISSUES", project_key);
+        let path = format!(
+            "/mypermissions?projectKey={}&permissions=CREATE_ISSUES",
+            project_key
+        );
 
         #[derive(Deserialize)]
         struct PermissionsResponse {
@@ -277,7 +279,8 @@ impl JiraClient {
 
         match self.get::<PermissionsResponse>(&path).await {
             Ok(resp) => {
-                let can_create = resp.permissions
+                let can_create = resp
+                    .permissions
                     .get("CREATE_ISSUES")
                     .map(|p| p.have_permission)
                     .unwrap_or(false);
@@ -316,15 +319,25 @@ impl JiraClient {
         let mut searchable: Vec<_> = fields.iter().filter(|f| f.searchable).collect();
         searchable.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
 
-        println!("{:<30} {:<25} {:<15} {}", "Name", "JQL Clause", "Type", "ID");
+        println!(
+            "{:<30} {:<25} {:<15} {}",
+            "Name", "JQL Clause", "Type", "ID"
+        );
         println!("{}", "-".repeat(85));
 
         for field in &searchable {
-            let clause = field.clause_names.first().map(|s| s.as_str()).unwrap_or(&field.id);
-            let field_type = field.schema.as_ref()
+            let clause = field
+                .clause_names
+                .first()
+                .map(|s| s.as_str())
+                .unwrap_or(&field.id);
+            let field_type = field
+                .schema
+                .as_ref()
                 .and_then(|s| s.field_type.as_deref())
                 .unwrap_or("unknown");
-            println!("{:<30} {:<25} {:<15} {}",
+            println!(
+                "{:<30} {:<25} {:<15} {}",
                 truncate(&field.name, 29),
                 truncate(clause, 24),
                 truncate(field_type, 14),
@@ -363,24 +376,14 @@ impl JiraClient {
             jira_issue.fields.issuetype.name
         )));
 
-        let priority = map_jira_priority(
-            jira_issue
-                .fields
-                .priority
-                .as_ref()
-                .map(|p| p.name.as_str()),
-        );
+        let priority =
+            map_jira_priority(jira_issue.fields.priority.as_ref().map(|p| p.name.as_str()));
 
         let assignees: Vec<String> = jira_issue
             .fields
             .assignee
             .as_ref()
-            .map(|a| {
-                a.display_name
-                    .as_ref()
-                    .unwrap_or(&a.account_id)
-                    .clone()
-            })
+            .map(|a| a.display_name.as_ref().unwrap_or(&a.account_id).clone())
             .into_iter()
             .collect();
 
@@ -420,7 +423,11 @@ impl JiraClient {
     }
 
     /// Internal list_issues with optional since filter for incremental sync
-    pub async fn list_issues_internal(&self, repo: &Repo, since: Option<DateTime<Utc>>) -> Result<FetchResult<Issue>> {
+    pub async fn list_issues_internal(
+        &self,
+        repo: &Repo,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<FetchResult<Issue>> {
         let project_key = &repo.name;
 
         let mut all_issues = Vec::new();
@@ -467,7 +474,11 @@ impl JiraClient {
     }
 
     /// Internal list_all_comments with optional since filter for incremental sync
-    pub async fn list_all_comments_internal(&self, repo: &Repo, since: Option<DateTime<Utc>>) -> Result<FetchResult<db::Comment>> {
+    pub async fn list_all_comments_internal(
+        &self,
+        repo: &Repo,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<FetchResult<db::Comment>> {
         let project_key = &repo.name;
 
         let mut all_comments = Vec::new();
@@ -594,7 +605,14 @@ impl JiraClient {
     }
 
     /// Create an issue
-    pub async fn create_issue(&self, repo: &Repo, title: &str, body: Option<&str>, labels: &[String], issue_type: &str) -> Result<Issue> {
+    pub async fn create_issue(
+        &self,
+        repo: &Repo,
+        title: &str,
+        body: Option<&str>,
+        labels: &[String],
+        issue_type: &str,
+    ) -> Result<Issue> {
         let project_key = &repo.name;
 
         let description_adf = body.map(markdown_to_adf);

--- a/src/forges/jira/mod.rs
+++ b/src/forges/jira/mod.rs
@@ -13,19 +13,25 @@ mod client;
 mod oauth;
 mod types;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 pub use client::JiraClient;
-pub use oauth::{get_accessible_resources, get_credentials_from_env, get_stored_credentials, oauth_flow, store_credentials, JiraAuthMode, JiraCredentials};
 #[allow(unused_imports)]
-pub use oauth::{refresh_token, AccessibleResource, TokenResponse};
+pub use oauth::{AccessibleResource, TokenResponse, refresh_token};
+pub use oauth::{
+    JiraAuthMode, JiraCredentials, get_accessible_resources, get_credentials_from_env,
+    get_stored_credentials, oauth_flow, store_credentials,
+};
 #[allow(unused_imports)]
 pub use types::{JiraProject, JiraUser, JiraVersion};
 
-use super::{AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
+use super::{
+    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal,
+    GoalState, Issue, Label, LinkArgs, LinkResult, RateLimitInfo,
+};
 use crate::repo::Repo;
 use crate::{config, db, repo};
 
@@ -47,12 +53,14 @@ pub const DEFAULT_ON_START_TOML: &str = "transition = \"In Progress\"\nassign_se
 
 /// Default [on_cleanup] config for JIRA repos
 /// Commented out by default since moving issues back may not be desired
-pub const DEFAULT_ON_CLEANUP_TOML: &str = "# transition = \"To Do\"  # Optional: move issue back to backlog\n";
+pub const DEFAULT_ON_CLEANUP_TOML: &str =
+    "# transition = \"To Do\"  # Optional: move issue back to backlog\n";
 
 // OAuth configuration (pub(super) for use in oauth.rs)
 pub(super) const JIRA_CLIENT_ID: &str = "VG2jV3YlB3mSWdHcLRZJ8kawl6BFWki8";
 pub(super) const JIRA_AUTH_URL: &str = "https://auth.atlassian.com/authorize";
-pub(super) const JIRA_RESOURCES_URL: &str = "https://api.atlassian.com/oauth/token/accessible-resources";
+pub(super) const JIRA_RESOURCES_URL: &str =
+    "https://api.atlassian.com/oauth/token/accessible-resources";
 pub(super) const REDIRECT_PORT: u16 = 19285;
 
 // OAuth proxy service (handles token exchange with client_secret)
@@ -60,7 +68,8 @@ pub(super) const SERVICE_URL: &str = "https://isq-jira-oauth.fly.dev";
 pub(super) const REDIRECT_URI: &str = "https://isq-jira-oauth.fly.dev/callback";
 
 // OAuth scopes
-pub(super) const JIRA_SCOPES: &str = "read:jira-work write:jira-work read:jira-user manage:jira-project offline_access";
+pub(super) const JIRA_SCOPES: &str =
+    "read:jira-work write:jira-work read:jira-user manage:jira-project offline_access";
 
 // ============================================================================
 // Helper Functions
@@ -103,7 +112,9 @@ pub(super) fn parse_jira_error(status: reqwest::StatusCode, body: &str) -> anyho
             for (field, msg) in errors {
                 if let Some(msg_str) = msg.as_str() {
                     let hint = match field.as_str() {
-                        "issuetype" => " (hint: run `isq issue list -o jql=\"project=PROJ\" --json` to see valid issue types, or use -o type=Task)",
+                        "issuetype" => {
+                            " (hint: run `isq issue list -o jql=\"project=PROJ\" --json` to see valid issue types, or use -o type=Task)"
+                        }
                         _ => "",
                     };
                     messages.push(format!("{}: {}{}", field, msg_str, hint));
@@ -184,7 +195,9 @@ pub fn get_credentials_for_repo(_repo_id: &str) -> Result<JiraCredentials> {
     if let Ok(creds) = get_credentials_from_env() {
         return Ok(creds);
     }
-    Err(anyhow!("No JIRA credentials found. Run 'isq link jira' or set JIRA_API_TOKEN"))
+    Err(anyhow!(
+        "No JIRA credentials found. Run 'isq link jira' or set JIRA_API_TOKEN"
+    ))
 }
 
 // ============================================================================
@@ -251,7 +264,9 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
         let creds = JiraCredentials {
             access_token: token.access_token,
             refresh_token: token.refresh_token,
-            auth_mode: JiraAuthMode::OAuth { cloud_id: site.id.clone() },
+            auth_mode: JiraAuthMode::OAuth {
+                cloud_id: site.id.clone(),
+            },
             site_url: site.url.clone(),
             expires_at,
         };
@@ -342,7 +357,15 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
 
     // Save to database
     let full_display_name = format!("{} ({})", project.name, display_name);
-    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &forge_repo, Some(&full_display_name), Some(&user.account_id), Some(&display_name))?;
+    db::set_repo_link(
+        &conn,
+        repo_path,
+        forge_type.as_str(),
+        &forge_repo,
+        Some(&full_display_name),
+        Some(&user.account_id),
+        Some(&display_name),
+    )?;
     db::save_issues(&conn, &forge_repo, &issues.items, true, true)?;
     db::add_watched_repo(&conn, repo_path)?;
 
@@ -382,14 +405,25 @@ impl Forge for JiraClient {
         self.list_issues_internal(repo, None).await
     }
 
-    async fn list_issues_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<Issue>> {
+    async fn list_issues_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<Issue>> {
         self.list_issues_internal(repo, Some(since)).await
     }
 
     async fn create_issue(&self, repo: &Repo, req: CreateIssueRequest) -> Result<Issue> {
         // Get issue type from opts, or default to "Task"
         let issue_type = req.opts.get("type").map(|s| s.as_str()).unwrap_or("Task");
-        self.create_issue(repo, &req.title, req.body.as_deref(), &req.labels, issue_type).await
+        self.create_issue(
+            repo,
+            &req.title,
+            req.body.as_deref(),
+            &req.labels,
+            issue_type,
+        )
+        .await
     }
 
     async fn create_comment(&self, _repo: &Repo, issue_id: &str, body: &str) -> Result<()> {
@@ -490,7 +524,11 @@ impl Forge for JiraClient {
         self.list_all_comments_internal(repo, None).await
     }
 
-    async fn list_comments_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<db::Comment>> {
+    async fn list_comments_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<db::Comment>> {
         self.list_all_comments_internal(repo, Some(since)).await
     }
 
@@ -506,7 +544,10 @@ impl Forge for JiraClient {
         let project: types::JiraProject = self.get(&project_path).await?;
 
         let project_id: i64 = project.id.parse().map_err(|_| {
-            anyhow!("Invalid project ID '{}' - expected numeric value", project.id)
+            anyhow!(
+                "Invalid project ID '{}' - expected numeric value",
+                project.id
+            )
         })?;
 
         let body = serde_json::json!({
@@ -664,16 +705,20 @@ impl Forge for JiraClient {
     }
 
     fn validate_on_cleanup_config(&self, config: &toml::Value) -> Result<()> {
-        let _: JiraOnCleanupConfig = config.clone().try_into().context(
-            "Invalid [on_cleanup] config for JIRA. Expected: transition = \"To Do\"",
-        )?;
+        let _: JiraOnCleanupConfig = config
+            .clone()
+            .try_into()
+            .context("Invalid [on_cleanup] config for JIRA. Expected: transition = \"To Do\"")?;
         Ok(())
     }
 
     async fn handle_command(&self, command: &str, _args: &[String]) -> Result<()> {
         match command {
             "list-fields" => self.list_fields().await,
-            _ => Err(anyhow!("Unknown command: {}. Available commands: list-fields", command)),
+            _ => Err(anyhow!(
+                "Unknown command: {}. Available commands: list-fields",
+                command
+            )),
         }
     }
 

--- a/src/forges/jira/oauth.rs
+++ b/src/forges/jira/oauth.rs
@@ -3,13 +3,16 @@
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 
-use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use rand::Rng;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-use super::{urlencoding, AUTH, JIRA_AUTH_URL, JIRA_CLIENT_ID, JIRA_RESOURCES_URL, JIRA_SCOPES, REDIRECT_PORT, REDIRECT_URI, SERVICE_URL};
+use super::{
+    AUTH, JIRA_AUTH_URL, JIRA_CLIENT_ID, JIRA_RESOURCES_URL, JIRA_SCOPES, REDIRECT_PORT,
+    REDIRECT_URI, SERVICE_URL, urlencoding,
+};
 
 /// Token response from JIRA OAuth
 #[derive(Deserialize)]
@@ -85,8 +88,13 @@ fn build_auth_url(code_challenge: &str, code_verifier: &str) -> String {
 /// Start a local server and wait for the OAuth callback from the proxy service
 /// The service redirects here with either ?tokens=<base64> or ?error=<base64>
 fn wait_for_callback() -> Result<TokenResponse> {
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", REDIRECT_PORT))
-        .map_err(|e| anyhow!("Failed to start local server on port {}: {}", REDIRECT_PORT, e))?;
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", REDIRECT_PORT)).map_err(|e| {
+        anyhow!(
+            "Failed to start local server on port {}: {}",
+            REDIRECT_PORT,
+            e
+        )
+    })?;
 
     listener.set_nonblocking(false)?;
 
@@ -112,8 +120,13 @@ fn wait_for_callback() -> Result<TokenResponse> {
                 // Check for error from service
                 if let Some(error_b64) = params.get("error") {
                     let error_bytes = URL_SAFE_NO_PAD.decode(error_b64).unwrap_or_default();
-                    let error_msg = String::from_utf8(error_bytes).unwrap_or_else(|_| "Unknown error".to_string());
-                    send_response(&mut stream, false, &format!("Authorization failed: {}", error_msg))?;
+                    let error_msg = String::from_utf8(error_bytes)
+                        .unwrap_or_else(|_| "Unknown error".to_string());
+                    send_response(
+                        &mut stream,
+                        false,
+                        &format!("Authorization failed: {}", error_msg),
+                    )?;
                     return Err(anyhow!("OAuth error: {}", error_msg));
                 }
 
@@ -122,7 +135,8 @@ fn wait_for_callback() -> Result<TokenResponse> {
                     .get("tokens")
                     .ok_or_else(|| anyhow!("Missing tokens parameter"))?;
 
-                let tokens_bytes = URL_SAFE_NO_PAD.decode(tokens_b64)
+                let tokens_bytes = URL_SAFE_NO_PAD
+                    .decode(tokens_b64)
                     .map_err(|_| anyhow!("Failed to decode tokens"))?;
                 let tokens_json = String::from_utf8(tokens_bytes)
                     .map_err(|_| anyhow!("Invalid tokens encoding"))?;
@@ -296,11 +310,13 @@ pub fn store_credentials(creds: &JiraCredentials) -> Result<()> {
 /// Try to get credentials from JIRA_API_TOKEN env var (for headless/CI use)
 /// Format: {"email":"user@acme.com","token":"abc123","site":"acme.atlassian.net"}
 pub fn get_credentials_from_env() -> Result<JiraCredentials> {
-    let env_val = std::env::var(AUTH.env_var)
-        .map_err(|_| anyhow!("JIRA_API_TOKEN not set"))?;
+    let env_val = std::env::var(AUTH.env_var).map_err(|_| anyhow!("JIRA_API_TOKEN not set"))?;
 
-    let json: serde_json::Value = serde_json::from_str(&env_val)
-        .map_err(|_| anyhow!("JIRA_API_TOKEN must be JSON: {{\"email\":\"...\",\"token\":\"...\",\"site\":\"...\"}}"))?;
+    let json: serde_json::Value = serde_json::from_str(&env_val).map_err(|_| {
+        anyhow!(
+            "JIRA_API_TOKEN must be JSON: {{\"email\":\"...\",\"token\":\"...\",\"site\":\"...\"}}"
+        )
+    })?;
 
     let email = json["email"]
         .as_str()

--- a/src/forges/linear/client.rs
+++ b/src/forges/linear/client.rs
@@ -2,15 +2,15 @@
 
 use std::sync::RwLock;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use super::oauth::refresh_token;
 use super::types::*;
-use super::{map_linear_priority, AUTH, GRAPHQL_URL};
-use crate::forges::{create_http_client, CreateGoalRequest, FetchResult, Issue, Label};
+use super::{AUTH, GRAPHQL_URL, map_linear_priority};
 use crate::db;
+use crate::forges::{CreateGoalRequest, FetchResult, Issue, Label, create_http_client};
 
 /// Linear GraphQL client
 pub struct LinearClient {
@@ -50,7 +50,11 @@ impl LinearClient {
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await?;
-            anyhow::bail!("Linear API error {} Unauthorized: {}", status.as_u16(), body);
+            anyhow::bail!(
+                "Linear API error {} Unauthorized: {}",
+                status.as_u16(),
+                body
+            );
         }
 
         let result: GraphQLResponse<T> = response.json().await?;
@@ -60,24 +64,27 @@ impl LinearClient {
             anyhow::bail!("Linear GraphQL errors: {}", messages.join(", "));
         }
 
-        result.data.ok_or_else(|| anyhow::anyhow!("No data in response"))
+        result
+            .data
+            .ok_or_else(|| anyhow::anyhow!("No data in response"))
     }
 
     /// Refresh the access token using the stored refresh token
     async fn do_refresh_token(&self) -> Result<()> {
-        let cred = AUTH.get_credential()?
+        let cred = AUTH
+            .get_credential()?
             .ok_or_else(|| anyhow!("No Linear credentials found"))?;
 
-        let stored_refresh_token = cred.refresh_token
-            .ok_or_else(|| anyhow!("No refresh token available - please re-authenticate with: isq link linear"))?;
+        let stored_refresh_token = cred.refresh_token.ok_or_else(|| {
+            anyhow!("No refresh token available - please re-authenticate with: isq link linear")
+        })?;
 
         let new_tokens = refresh_token(&stored_refresh_token).await?;
 
         // Update stored credentials in OS keyring
-        let expires_at = new_tokens.expires_in.map(|secs| {
-            (chrono::Utc::now() + chrono::Duration::seconds(secs as i64))
-                .to_rfc3339()
-        });
+        let expires_at = new_tokens
+            .expires_in
+            .map(|secs| (chrono::Utc::now() + chrono::Duration::seconds(secs as i64)).to_rfc3339());
         AUTH.store_credential(
             &new_tokens.access_token,
             new_tokens.refresh_token.as_deref(),
@@ -160,7 +167,11 @@ impl LinearClient {
     }
 
     /// Get issue by number within a team (returns id and label IDs for mutations)
-    pub async fn get_issue_by_number(&self, team_id: &str, number: u64) -> Result<LinearIssueWithDetails> {
+    pub async fn get_issue_by_number(
+        &self,
+        team_id: &str,
+        number: u64,
+    ) -> Result<LinearIssueWithDetails> {
         let query = r#"
             query($teamId: ID!, $number: Float!) {
                 issues(filter: { team: { id: { eq: $teamId } }, number: { eq: $number } }, first: 1) {
@@ -179,12 +190,20 @@ impl LinearClient {
 
         let response: SingleIssueListResponse = self.query(query, Some(variables)).await?;
 
-        response.issues.nodes.into_iter().next()
+        response
+            .issues
+            .nodes
+            .into_iter()
+            .next()
             .ok_or_else(|| anyhow::anyhow!("Issue #{} not found in team", number))
     }
 
     /// Get workflow state by type (completed, started, backlog, etc.)
-    pub async fn get_state_by_type(&self, team_id: &str, state_type: &str) -> Result<WorkflowState> {
+    pub async fn get_state_by_type(
+        &self,
+        team_id: &str,
+        state_type: &str,
+    ) -> Result<WorkflowState> {
         let query = r#"
             query($teamId: ID!) {
                 workflowStates(filter: { team: { id: { eq: $teamId } } }) {
@@ -200,7 +219,9 @@ impl LinearClient {
         let variables = serde_json::json!({ "teamId": team_id });
         let response: WorkflowStatesResponse = self.query(query, Some(variables)).await?;
 
-        response.workflow_states.nodes
+        response
+            .workflow_states
+            .nodes
             .into_iter()
             .find(|s| s.state_type == state_type)
             .ok_or_else(|| anyhow::anyhow!("No workflow state of type '{}' found", state_type))
@@ -208,7 +229,11 @@ impl LinearClient {
 
     /// Get workflow state by type OR name
     /// Tries matching by type first (stable), then by name (customizable)
-    pub async fn get_state_by_type_or_name(&self, team_id: &str, type_or_name: &str) -> Result<WorkflowState> {
+    pub async fn get_state_by_type_or_name(
+        &self,
+        team_id: &str,
+        type_or_name: &str,
+    ) -> Result<WorkflowState> {
         let query = r#"
             query($teamId: ID!) {
                 workflowStates(filter: { team: { id: { eq: $teamId } } }) {
@@ -227,23 +252,35 @@ impl LinearClient {
         let type_or_name_lower = type_or_name.to_lowercase();
 
         // Try to match by type first (stable identifiers)
-        if let Some(state) = response.workflow_states.nodes.iter()
+        if let Some(state) = response
+            .workflow_states
+            .nodes
+            .iter()
             .find(|s| s.state_type.to_lowercase() == type_or_name_lower)
         {
             return Ok(state.clone());
         }
 
         // Fall back to matching by name
-        response.workflow_states.nodes
+        response
+            .workflow_states
+            .nodes
             .into_iter()
             .find(|s| s.name.as_ref().map(|n| n.to_lowercase()) == Some(type_or_name_lower.clone()))
             .ok_or_else(|| anyhow::anyhow!("No workflow state matching '{}' found", type_or_name))
     }
 
     /// Transition an issue to a workflow state
-    pub async fn transition_issue(&self, team_id: &str, issue_number: u64, state_type_or_name: &str) -> Result<()> {
+    pub async fn transition_issue(
+        &self,
+        team_id: &str,
+        issue_number: u64,
+        state_type_or_name: &str,
+    ) -> Result<()> {
         let issue = self.get_issue_by_number(team_id, issue_number).await?;
-        let state = self.get_state_by_type_or_name(team_id, state_type_or_name).await?;
+        let state = self
+            .get_state_by_type_or_name(team_id, state_type_or_name)
+            .await?;
 
         let query = r#"
             mutation($issueId: String!, $stateId: String!) {
@@ -283,14 +320,21 @@ impl LinearClient {
 
         // Try to match by name (case-insensitive) or email
         let name_lower = name.to_lowercase();
-        response.users.nodes
+        response
+            .users
+            .nodes
             .into_iter()
             .find(|u| u.name.to_lowercase() == name_lower || u.email.to_lowercase() == name_lower)
             .ok_or_else(|| anyhow::anyhow!("User '{}' not found", name))
     }
 
     /// Assign issue by user ID directly (no name lookup)
-    pub async fn assign_issue_by_id(&self, team_id: &str, issue_number: u64, user_id: &str) -> Result<()> {
+    pub async fn assign_issue_by_id(
+        &self,
+        team_id: &str,
+        issue_number: u64,
+        user_id: &str,
+    ) -> Result<()> {
         let issue = self.get_issue_by_number(team_id, issue_number).await?;
 
         let query = r#"
@@ -314,7 +358,11 @@ impl LinearClient {
     }
 
     /// Get labels by name for a team
-    pub async fn get_label_ids(&self, team_id: &str, label_names: &[String]) -> Result<Vec<String>> {
+    pub async fn get_label_ids(
+        &self,
+        team_id: &str,
+        label_names: &[String],
+    ) -> Result<Vec<String>> {
         let query = r#"
             query($teamId: ID!) {
                 team(id: $teamId) {
@@ -335,7 +383,11 @@ impl LinearClient {
         let mut label_ids = Vec::new();
         for name in label_names {
             let name_lower = name.to_lowercase();
-            if let Some(label) = response.team.labels.nodes.iter()
+            if let Some(label) = response
+                .team
+                .labels
+                .nodes
+                .iter()
                 .find(|l| l.name.to_lowercase() == name_lower)
             {
                 label_ids.push(label.id.clone());
@@ -347,7 +399,11 @@ impl LinearClient {
 
     /// List issues for a team (with pagination)
     /// Returns FetchResult with completeness tracking
-    pub async fn list_team_issues_internal(&self, team_id: &str, since: Option<DateTime<Utc>>) -> Result<FetchResult<Issue>> {
+    pub async fn list_team_issues_internal(
+        &self,
+        team_id: &str,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<FetchResult<Issue>> {
         // Fetch org URL key for constructing issue URLs
         let org = self.get_organization().await?;
         let url_key = org.url_key;
@@ -357,7 +413,10 @@ impl LinearClient {
         let mut page = 0;
 
         loop {
-            match self.fetch_issues_page(team_id, &url_key, cursor.as_deref(), since.as_ref()).await {
+            match self
+                .fetch_issues_page(team_id, &url_key, cursor.as_deref(), since.as_ref())
+                .await
+            {
                 Ok((issues, page_info)) => {
                     all_issues.extend(issues);
                     page += 1;
@@ -388,7 +447,13 @@ impl LinearClient {
 
     /// Fetch a single page of issues
     /// When since is provided, uses updatedAt filter and orderBy for incremental sync
-    async fn fetch_issues_page(&self, team_id: &str, url_key: &str, after: Option<&str>, since: Option<&DateTime<Utc>>) -> Result<(Vec<Issue>, PageInfo)> {
+    async fn fetch_issues_page(
+        &self,
+        team_id: &str,
+        url_key: &str,
+        after: Option<&str>,
+        since: Option<&DateTime<Utc>>,
+    ) -> Result<(Vec<Issue>, PageInfo)> {
         // Use different query for incremental vs full sync
         let query = if since.is_some() {
             r#"
@@ -491,33 +556,49 @@ impl LinearClient {
 
         let response: IssuesResponse = self.query(query, Some(variables)).await?;
 
-        let page_info = response.issues.page_info
-            .unwrap_or(PageInfo { has_next_page: false, end_cursor: None });
+        let page_info = response.issues.page_info.unwrap_or(PageInfo {
+            has_next_page: false,
+            end_cursor: None,
+        });
 
         // Convert Linear issues to our Issue format
-        let issues = response.issues.nodes.into_iter().map(|i| {
-            let url = format!("https://linear.app/{}/issue/{}", url_key, i.identifier);
-            let priority = map_linear_priority(i.priority);
-            Issue {
-                id: i.identifier,
-                title: i.title,
-                body: i.description,
-                state: if i.state.state_type == "completed" || i.state.state_type == "canceled" {
-                    "closed".to_string()
-                } else {
-                    "open".to_string()
-                },
-                author: i.creator.map(|c| c.name).unwrap_or_else(|| "unknown".to_string()),
-                labels: i.labels.nodes.into_iter().map(|l| Label::new(l.name, Some(l.color))).collect(),
-                assignees: i.assignee.map(|a| vec![a.display_name]).unwrap_or_default(),
-                priority,
-                priority_label: None, // Linear uses native priority, not labels
-                created_at: i.created_at,
-                updated_at: i.updated_at,
-                url: Some(url),
-                milestone: i.project.map(|p| p.name),
-            }
-        }).collect();
+        let issues = response
+            .issues
+            .nodes
+            .into_iter()
+            .map(|i| {
+                let url = format!("https://linear.app/{}/issue/{}", url_key, i.identifier);
+                let priority = map_linear_priority(i.priority);
+                Issue {
+                    id: i.identifier,
+                    title: i.title,
+                    body: i.description,
+                    state: if i.state.state_type == "completed" || i.state.state_type == "canceled"
+                    {
+                        "closed".to_string()
+                    } else {
+                        "open".to_string()
+                    },
+                    author: i
+                        .creator
+                        .map(|c| c.name)
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    labels: i
+                        .labels
+                        .nodes
+                        .into_iter()
+                        .map(|l| Label::new(l.name, Some(l.color)))
+                        .collect(),
+                    assignees: i.assignee.map(|a| vec![a.display_name]).unwrap_or_default(),
+                    priority,
+                    priority_label: None, // Linear uses native priority, not labels
+                    created_at: i.created_at,
+                    updated_at: i.updated_at,
+                    url: Some(url),
+                    milestone: i.project.map(|p| p.name),
+                }
+            })
+            .collect();
 
         Ok((issues, page_info))
     }
@@ -548,7 +629,11 @@ impl LinearClient {
     }
 
     /// Create a new project
-    pub async fn create_project(&self, team_id: &str, req: &CreateGoalRequest) -> Result<LinearProject> {
+    pub async fn create_project(
+        &self,
+        team_id: &str,
+        req: &CreateGoalRequest,
+    ) -> Result<LinearProject> {
         let query = r#"
             mutation($input: ProjectCreateInput!) {
                 projectCreate(input: $input) {
@@ -588,7 +673,9 @@ impl LinearClient {
             anyhow::bail!("Failed to create project");
         }
 
-        response.project_create.project
+        response
+            .project_create
+            .project
             .ok_or_else(|| anyhow::anyhow!("Project created but not returned"))
     }
 
@@ -642,7 +729,11 @@ impl LinearClient {
 
     /// List all comments for a team with optional since filter
     /// Uses direct comments query with pagination
-    pub async fn list_comments_internal(&self, team_id: &str, since: Option<DateTime<Utc>>) -> Result<FetchResult<db::Comment>> {
+    pub async fn list_comments_internal(
+        &self,
+        team_id: &str,
+        since: Option<DateTime<Utc>>,
+    ) -> Result<FetchResult<db::Comment>> {
         let mut all_comments = Vec::new();
         let mut cursor: Option<String> = None;
         let mut page = 0;
@@ -724,7 +815,10 @@ impl LinearClient {
                             comment_id: comment.id,
                             issue_id: comment.issue.identifier.clone(),
                             body: comment.body,
-                            author: comment.user.map(|u| u.name).unwrap_or_else(|| "unknown".to_string()),
+                            author: comment
+                                .user
+                                .map(|u| u.name)
+                                .unwrap_or_else(|| "unknown".to_string()),
                             created_at: comment.created_at,
                             updated_at: Some(comment.updated_at),
                         });
@@ -736,8 +830,10 @@ impl LinearClient {
                         eprintln!("  {} comments...", all_comments.len());
                     }
 
-                    let page_info = response.comments.page_info
-                        .unwrap_or(PageInfo { has_next_page: false, end_cursor: None });
+                    let page_info = response.comments.page_info.unwrap_or(PageInfo {
+                        has_next_page: false,
+                        end_cursor: None,
+                    });
 
                     if !page_info.has_next_page {
                         break;

--- a/src/forges/linear/mod.rs
+++ b/src/forges/linear/mod.rs
@@ -10,7 +10,7 @@ mod client;
 mod oauth;
 mod types;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
@@ -18,11 +18,14 @@ use serde::Deserialize;
 pub use client::LinearClient;
 pub use oauth::oauth_flow;
 #[allow(unused_imports)]
-pub use oauth::{refresh_token, TokenResponse};
+pub use oauth::{TokenResponse, refresh_token};
 #[allow(unused_imports)]
 pub use types::{LinearOrganization, LinearProject, LinearTeam};
 
-use super::{AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, Issue, Label, LinkArgs, LinkResult, RateLimitInfo};
+use super::{
+    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, Issue,
+    Label, LinkArgs, LinkResult, RateLimitInfo,
+};
 use crate::repo::Repo;
 use crate::{config, db, repo};
 
@@ -45,7 +48,8 @@ pub const DEFAULT_ON_START_TOML: &str = "transition = \"started\"\nassign_self =
 
 /// Default [on_cleanup] config for Linear repos
 /// Commented out by default since moving issues back to backlog may not be desired
-pub const DEFAULT_ON_CLEANUP_TOML: &str = "# transition = \"backlog\"  # Optional: move issue back to backlog\n";
+pub const DEFAULT_ON_CLEANUP_TOML: &str =
+    "# transition = \"backlog\"  # Optional: move issue back to backlog\n";
 
 // API endpoints
 pub(super) const GRAPHQL_URL: &str = "https://api.linear.app/graphql";
@@ -182,21 +186,28 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
     // Resolve team from -o team=X argument or auto-select if only one
     let team = if let Some(team_query) = args.get("team") {
         let query_lower = team_query.to_lowercase();
-        teams.iter().find(|t| {
-            t.name.to_lowercase() == query_lower || t.key.to_lowercase() == query_lower
-        }).ok_or_else(|| {
-            let available: Vec<_> = teams.iter().map(|t| format!("{} ({})", t.name, t.key)).collect();
-            anyhow!(
-                "Team '{}' not found.\n\nAvailable teams:\n  {}",
-                team_query,
-                available.join("\n  ")
-            )
-        })?
+        teams
+            .iter()
+            .find(|t| t.name.to_lowercase() == query_lower || t.key.to_lowercase() == query_lower)
+            .ok_or_else(|| {
+                let available: Vec<_> = teams
+                    .iter()
+                    .map(|t| format!("{} ({})", t.name, t.key))
+                    .collect();
+                anyhow!(
+                    "Team '{}' not found.\n\nAvailable teams:\n  {}",
+                    team_query,
+                    available.join("\n  ")
+                )
+            })?
     } else if teams.len() == 1 {
         println!("Using team: {} ({})", teams[0].name, teams[0].key);
         &teams[0]
     } else {
-        let available: Vec<_> = teams.iter().map(|t| format!("{} ({})", t.name, t.key)).collect();
+        let available: Vec<_> = teams
+            .iter()
+            .map(|t| format!("{} ({})", t.name, t.key))
+            .collect();
         anyhow::bail!(
             "Multiple teams available. Specify one with -o team=<name>.\n\nAvailable teams:\n  {}\n\nExample: isq link linear -o team=\"{}\"",
             available.join("\n  "),
@@ -220,8 +231,22 @@ pub async fn link(repo_path: &str, args: &LinkArgs) -> Result<LinkResult> {
     let issues_result = client.list_team_issues_internal(&team.id, None).await?;
 
     // Save to database (user_id for API calls, user_display_name for --mine filter)
-    db::set_repo_link(&conn, repo_path, forge_type.as_str(), &forge_repo, Some(&display_name), Some(&user_id), Some(&user_display_name))?;
-    db::save_issues(&conn, &forge_repo, &issues_result.items, true, issues_result.is_complete)?;
+    db::set_repo_link(
+        &conn,
+        repo_path,
+        forge_type.as_str(),
+        &forge_repo,
+        Some(&display_name),
+        Some(&user_id),
+        Some(&user_display_name),
+    )?;
+    db::save_issues(
+        &conn,
+        &forge_repo,
+        &issues_result.items,
+        true,
+        issues_result.is_complete,
+    )?;
     db::add_watched_repo(&conn, repo_path)?;
 
     // Create .config/isq.toml with defaults
@@ -254,8 +279,13 @@ impl Forge for LinearClient {
         self.list_team_issues_internal(&repo.name, None).await
     }
 
-    async fn list_issues_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<Issue>> {
-        self.list_team_issues_internal(&repo.name, Some(since)).await
+    async fn list_issues_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<Issue>> {
+        self.list_team_issues_internal(&repo.name, Some(since))
+            .await
     }
 
     async fn create_issue(&self, repo: &Repo, req: CreateIssueRequest) -> Result<Issue> {
@@ -315,7 +345,10 @@ impl Forge for LinearClient {
 
         let response: types::IssueCreateResponse = self.query(query, Some(variables)).await?;
         let created = response.issue_create.issue;
-        let url = format!("https://linear.app/{}/issue/{}", org.url_key, created.identifier);
+        let url = format!(
+            "https://linear.app/{}/issue/{}",
+            org.url_key, created.identifier
+        );
 
         Ok(Issue {
             id: created.identifier,
@@ -325,7 +358,7 @@ impl Forge for LinearClient {
             author: "me".to_string(),
             labels: req.labels.into_iter().map(Label::name_only).collect(),
             assignees: vec![], // Not returned by mutation
-            priority: 4, // Default: none (not returned by mutation)
+            priority: 4,       // Default: none (not returned by mutation)
             priority_label: None,
             created_at: String::new(), // Not returned by mutation
             updated_at: String::new(),
@@ -392,7 +425,7 @@ impl Forge for LinearClient {
             Err(_) => match self.get_state_by_type(&repo.name, "unstarted").await {
                 Ok(state) => state,
                 Err(_) => self.get_state_by_type(&repo.name, "started").await?,
-            }
+            },
         };
 
         let query = r#"
@@ -425,7 +458,8 @@ impl Forge for LinearClient {
         }
 
         // Get current label IDs and add the new one
-        let mut current_ids: Vec<String> = issue.labels.nodes.iter().map(|l| l.id.clone()).collect();
+        let mut current_ids: Vec<String> =
+            issue.labels.nodes.iter().map(|l| l.id.clone()).collect();
         if !current_ids.contains(&label_ids[0]) {
             current_ids.push(label_ids[0].clone());
         }
@@ -456,7 +490,10 @@ impl Forge for LinearClient {
 
         // Get current label IDs and remove the specified one
         let label_lower = label.to_lowercase();
-        let new_ids: Vec<String> = issue.labels.nodes.iter()
+        let new_ids: Vec<String> = issue
+            .labels
+            .nodes
+            .iter()
             .filter(|l| l.name.to_lowercase() != label_lower)
             .map(|l| l.id.clone())
             .collect();
@@ -485,14 +522,19 @@ impl Forge for LinearClient {
         let issue_number = parse_issue_number(issue_id)?;
         // CLI path: look up user by name/email to get their ID
         let user = self.get_user_by_name(assignee).await?;
-        self.assign_issue_by_id(&repo.name, issue_number, &user.id).await
+        self.assign_issue_by_id(&repo.name, issue_number, &user.id)
+            .await
     }
 
     async fn list_all_comments(&self, repo: &Repo) -> Result<FetchResult<crate::db::Comment>> {
         self.list_comments_internal(&repo.name, None).await
     }
 
-    async fn list_comments_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<crate::db::Comment>> {
+    async fn list_comments_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<crate::db::Comment>> {
         self.list_comments_internal(&repo.name, Some(since)).await
     }
 
@@ -557,12 +599,22 @@ impl Forge for LinearClient {
             .and_then(parse_reset_timestamp);
 
         match (remaining, reset_at) {
-            (Some(remaining), Some(reset_at)) => Ok(Some(RateLimitInfo { limit, remaining, reset_at })),
+            (Some(remaining), Some(reset_at)) => Ok(Some(RateLimitInfo {
+                limit,
+                remaining,
+                reset_at,
+            })),
             _ => Ok(None), // Headers not present, Linear may not always send them
         }
     }
 
-    async fn handle_on_start(&self, repo: &Repo, issue_id: &str, config: &toml::Value, user_id: Option<&str>) -> Result<()> {
+    async fn handle_on_start(
+        &self,
+        repo: &Repo,
+        issue_id: &str,
+        config: &toml::Value,
+        user_id: Option<&str>,
+    ) -> Result<()> {
         let issue_number = parse_issue_number(issue_id)?;
 
         // Parse Linear-specific config from opaque toml::Value
@@ -570,13 +622,15 @@ impl Forge for LinearClient {
 
         // Transition to configured workflow state
         if let Some(ref transition) = cfg.transition {
-            self.transition_issue(&repo.name, issue_number, transition).await?;
+            self.transition_issue(&repo.name, issue_number, transition)
+                .await?;
         }
 
         // Assign to self if configured (user_id is the Linear user UUID)
         if cfg.assign_self {
             if let Some(id) = user_id {
-                self.assign_issue_by_id(&repo.name, issue_number, id).await?;
+                self.assign_issue_by_id(&repo.name, issue_number, id)
+                    .await?;
             }
         }
 
@@ -614,10 +668,22 @@ impl Forge for LinearClient {
         }
 
         let response: TeamLabelsResponse = self.query(query, Some(variables)).await?;
-        Ok(response.team.labels.nodes.into_iter().map(|l| Label::new(l.name, Some(l.color))).collect())
+        Ok(response
+            .team
+            .labels
+            .nodes
+            .into_iter()
+            .map(|l| Label::new(l.name, Some(l.color)))
+            .collect())
     }
 
-    async fn create_label(&self, repo: &Repo, name: &str, color: Option<&str>, _description: Option<&str>) -> Result<Label> {
+    async fn create_label(
+        &self,
+        repo: &Repo,
+        name: &str,
+        color: Option<&str>,
+        _description: Option<&str>,
+    ) -> Result<Label> {
         // For Linear, repo.name is the team ID
         let query = r#"
             mutation($teamId: String!, $name: String!, $color: String) {
@@ -655,8 +721,9 @@ impl Forge for LinearClient {
     }
 
     fn validate_on_start_config(&self, config: &toml::Value) -> Result<()> {
-        let _: LinearOnStartConfig = config.clone().try_into()
-            .context("Invalid [on_start] config for Linear.\nValid fields: transition, assign_self")?;
+        let _: LinearOnStartConfig = config.clone().try_into().context(
+            "Invalid [on_start] config for Linear.\nValid fields: transition, assign_self",
+        )?;
         Ok(())
     }
 
@@ -674,7 +741,10 @@ impl Forge for LinearClient {
 
         // Transition to configured workflow state (optional)
         if let Some(ref transition) = cfg.transition {
-            if let Err(e) = self.transition_issue(&repo.name, issue_number, transition).await {
+            if let Err(e) = self
+                .transition_issue(&repo.name, issue_number, transition)
+                .await
+            {
                 eprintln!("Warning: could not transition issue: {}", e);
             }
         }
@@ -683,7 +753,9 @@ impl Forge for LinearClient {
     }
 
     fn validate_on_cleanup_config(&self, config: &toml::Value) -> Result<()> {
-        let _: LinearOnCleanupConfig = config.clone().try_into()
+        let _: LinearOnCleanupConfig = config
+            .clone()
+            .try_into()
             .context("Invalid [on_cleanup] config for Linear.\nValid fields: transition")?;
         Ok(())
     }

--- a/src/forges/linear/oauth.rs
+++ b/src/forges/linear/oauth.rs
@@ -3,12 +3,14 @@
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 
-use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use rand::Rng;
 use sha2::{Digest, Sha256};
 
-use super::{urlencoding, LINEAR_CLIENT_ID, LINEAR_AUTH_URL, LINEAR_TOKEN_URL, REDIRECT_PORT, REDIRECT_URI};
+use super::{
+    LINEAR_AUTH_URL, LINEAR_CLIENT_ID, LINEAR_TOKEN_URL, REDIRECT_PORT, REDIRECT_URI, urlencoding,
+};
 use crate::forges::create_http_client;
 
 /// Token response from Linear OAuth
@@ -49,8 +51,13 @@ fn build_auth_url(code_challenge: &str, state: &str) -> String {
 
 /// Start a local server and wait for the OAuth callback
 fn wait_for_callback(expected_state: &str) -> Result<String> {
-    let listener = TcpListener::bind(format!("127.0.0.1:{}", REDIRECT_PORT))
-        .map_err(|e| anyhow!("Failed to start local server on port {}: {}", REDIRECT_PORT, e))?;
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", REDIRECT_PORT)).map_err(|e| {
+        anyhow!(
+            "Failed to start local server on port {}: {}",
+            REDIRECT_PORT,
+            e
+        )
+    })?;
 
     listener.set_nonblocking(false)?;
 
@@ -75,18 +82,30 @@ fn wait_for_callback(expected_state: &str) -> Result<String> {
 
                 if let Some(error) = params.get("error") {
                     let description = params.get("error_description").unwrap_or(&"Unknown error");
-                    send_response(&mut stream, false, &format!("Authorization failed: {}", description))?;
+                    send_response(
+                        &mut stream,
+                        false,
+                        &format!("Authorization failed: {}", description),
+                    )?;
                     return Err(anyhow!("OAuth error: {} - {}", error, description));
                 }
 
-                let state = params.get("state").ok_or_else(|| anyhow!("Missing state parameter"))?;
+                let state = params
+                    .get("state")
+                    .ok_or_else(|| anyhow!("Missing state parameter"))?;
                 if *state != expected_state {
                     send_response(&mut stream, false, "State mismatch - possible CSRF attack")?;
                     return Err(anyhow!("State mismatch"));
                 }
 
-                let code = params.get("code").ok_or_else(|| anyhow!("Missing code parameter"))?;
-                send_response(&mut stream, true, "Authorization successful! You can close this tab.")?;
+                let code = params
+                    .get("code")
+                    .ok_or_else(|| anyhow!("Missing code parameter"))?;
+                send_response(
+                    &mut stream,
+                    true,
+                    "Authorization successful! You can close this tab.",
+                )?;
                 return Ok(code.to_string());
             }
         }
@@ -114,8 +133,7 @@ fn send_response(stream: &mut std::net::TcpStream, success: bool, message: &str)
 </div>
 </body>
 </html>"#,
-        color,
-        message
+        color, message
     );
 
     let response = format!(
@@ -142,11 +160,7 @@ async fn exchange_code(code: &str, code_verifier: &str) -> Result<TokenResponse>
         ("code_verifier", code_verifier),
     ];
 
-    let response = client
-        .post(LINEAR_TOKEN_URL)
-        .form(&params)
-        .send()
-        .await?;
+    let response = client.post(LINEAR_TOKEN_URL).form(&params).send().await?;
 
     if !response.status().is_success() {
         let status = response.status();
@@ -188,11 +202,7 @@ pub async fn refresh_token(refresh_token: &str) -> Result<TokenResponse> {
         ("refresh_token", refresh_token),
     ];
 
-    let response = client
-        .post(LINEAR_TOKEN_URL)
-        .form(&params)
-        .send()
-        .await?;
+    let response = client.post(LINEAR_TOKEN_URL).form(&params).send().await?;
 
     if !response.status().is_success() {
         let status = response.status();

--- a/src/forges/linear/types.rs
+++ b/src/forges/linear/types.rs
@@ -358,7 +358,7 @@ impl From<LinearProject> for Goal {
                 _ => GoalState::Open,
             },
             progress: p.progress,
-            open_count: None,  // Linear doesn't provide counts efficiently
+            open_count: None, // Linear doesn't provide counts efficiently
             closed_count: None,
             created_at: p.created_at,
             updated_at: p.updated_at,

--- a/src/forges/mod.rs
+++ b/src/forges/mod.rs
@@ -5,9 +5,9 @@ mod linear;
 use std::panic;
 use std::process::Command;
 
-use anyhow::{anyhow, Result};
-use reqwest::Client;
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use chrono::{DateTime, Utc};
@@ -64,12 +64,18 @@ pub struct FetchResult<T> {
 impl<T> FetchResult<T> {
     /// Create a complete fetch result
     pub fn complete(items: Vec<T>) -> Self {
-        Self { items, is_complete: true }
+        Self {
+            items,
+            is_complete: true,
+        }
     }
 
     /// Create an incomplete fetch result (partial failure)
     pub fn incomplete(items: Vec<T>) -> Self {
-        Self { items, is_complete: false }
+        Self {
+            items,
+            is_complete: false,
+        }
     }
 }
 
@@ -144,7 +150,12 @@ impl AuthConfig {
         refresh_token: Option<&str>,
         expires_at: Option<&str>,
     ) -> Result<()> {
-        credentials::set_credential(self.keyring_service, access_token, refresh_token, expires_at)
+        credentials::set_credential(
+            self.keyring_service,
+            access_token,
+            refresh_token,
+            expires_at,
+        )
     }
 
     /// Get the full credential (including refresh token) from keyring
@@ -318,8 +329,14 @@ pub struct LinkResult {
 
 /// Generate error message for repos not linked to a forge
 pub fn not_linked_error() -> anyhow::Error {
-    let forges: Vec<_> = ALL_FORGE_TYPES.iter().map(|f| format!("  isq link {}", f.as_str())).collect();
-    anyhow!("This repo is not linked to an issue tracker.\n\nRun one of:\n{}", forges.join("\n"))
+    let forges: Vec<_> = ALL_FORGE_TYPES
+        .iter()
+        .map(|f| format!("  isq link {}", f.as_str()))
+        .collect();
+    anyhow!(
+        "This repo is not linked to an issue tracker.\n\nRun one of:\n{}",
+        forges.join("\n")
+    )
 }
 
 impl ForgeType {
@@ -476,7 +493,11 @@ pub trait Forge: Send + Sync {
     async fn list_issues(&self, repo: &Repo) -> Result<FetchResult<Issue>>;
 
     /// List issues updated since timestamp (incremental fetch)
-    async fn list_issues_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<Issue>>;
+    async fn list_issues_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<Issue>>;
 
     /// Create a new issue
     async fn create_issue(&self, repo: &Repo, req: CreateIssueRequest) -> Result<Issue>;
@@ -503,7 +524,11 @@ pub trait Forge: Send + Sync {
     async fn list_all_comments(&self, repo: &Repo) -> Result<FetchResult<db::Comment>>;
 
     /// List comments updated since timestamp (incremental fetch)
-    async fn list_comments_since(&self, repo: &Repo, since: DateTime<Utc>) -> Result<FetchResult<db::Comment>>;
+    async fn list_comments_since(
+        &self,
+        repo: &Repo,
+        since: DateTime<Utc>,
+    ) -> Result<FetchResult<db::Comment>>;
 
     /// List all goals (GitHub: milestones, Linear: projects)
     async fn list_goals(&self, repo: &Repo) -> Result<Vec<Goal>>;
@@ -524,12 +549,24 @@ pub trait Forge: Send + Sync {
     async fn list_labels(&self, repo: &Repo) -> Result<Vec<Label>>;
 
     /// Create a label in the repo
-    async fn create_label(&self, repo: &Repo, name: &str, color: Option<&str>, description: Option<&str>) -> Result<Label>;
+    async fn create_label(
+        &self,
+        repo: &Repo,
+        name: &str,
+        color: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<Label>;
 
     /// Handle on_start lifecycle event for an issue
     /// Each forge interprets the config according to its own schema
     /// username is provided for assign_self functionality
-    async fn handle_on_start(&self, repo: &Repo, issue_id: &str, config: &toml::Value, username: Option<&str>) -> Result<()>;
+    async fn handle_on_start(
+        &self,
+        repo: &Repo,
+        issue_id: &str,
+        config: &toml::Value,
+        username: Option<&str>,
+    ) -> Result<()>;
 
     /// Validate on_start config before use
     /// Returns error with helpful message if config is invalid
@@ -538,7 +575,13 @@ pub trait Forge: Send + Sync {
     /// Handle on_cleanup lifecycle event for an issue
     /// Each forge interprets the config according to its own schema
     /// username is provided for potential unassignment functionality
-    async fn handle_on_cleanup(&self, repo: &Repo, issue_id: &str, config: &toml::Value, username: Option<&str>) -> Result<()>;
+    async fn handle_on_cleanup(
+        &self,
+        repo: &Repo,
+        issue_id: &str,
+        config: &toml::Value,
+        username: Option<&str>,
+    ) -> Result<()>;
 
     /// Validate on_cleanup config before use
     /// Returns error with helpful message if config is invalid
@@ -587,8 +630,7 @@ pub trait Forge: Send + Sync {
 /// Returns an error if the repo is not linked to a forge.
 pub fn get_forge_for_repo(repo_path: &str) -> Result<(Box<dyn Forge>, db::RepoLink)> {
     let conn = db::open()?;
-    let link = db::get_repo_link(&conn, repo_path)?
-        .ok_or_else(not_linked_error)?;
+    let link = db::get_repo_link(&conn, repo_path)?.ok_or_else(not_linked_error)?;
 
     let forge_type = ForgeType::from_str(&link.forge_type)
         .ok_or_else(|| anyhow!("Unknown forge type: {}", link.forge_type))?;

--- a/src/install.rs
+++ b/src/install.rs
@@ -163,8 +163,7 @@ pub fn write_receipt(receipt: &InstallReceipt) -> Result<bool> {
 pub fn update_receipt_version(new_version: &str) -> Result<()> {
     let path = receipt_path()?;
 
-    let mut receipt =
-        read_receipt()?.ok_or_else(|| anyhow::anyhow!("No install receipt found"))?;
+    let mut receipt = read_receipt()?.ok_or_else(|| anyhow::anyhow!("No install receipt found"))?;
 
     receipt.version = new_version.to_string();
 
@@ -384,15 +383,27 @@ mod tests {
     fn test_detect_from_path() {
         let cases = [
             // Homebrew paths
-            ("/opt/homebrew/Cellar/isq/0.1.0/bin/isq", InstallMethod::Homebrew),
-            ("/usr/local/Cellar/isq/0.1.0/bin/isq", InstallMethod::Homebrew),
-            ("/home/linuxbrew/.linuxbrew/Cellar/isq/0.1.0/bin/isq", InstallMethod::Homebrew),
+            (
+                "/opt/homebrew/Cellar/isq/0.1.0/bin/isq",
+                InstallMethod::Homebrew,
+            ),
+            (
+                "/usr/local/Cellar/isq/0.1.0/bin/isq",
+                InstallMethod::Homebrew,
+            ),
+            (
+                "/home/linuxbrew/.linuxbrew/Cellar/isq/0.1.0/bin/isq",
+                InstallMethod::Homebrew,
+            ),
             // Cargo paths
             ("/Users/cam/.cargo/bin/isq", InstallMethod::Cargo),
             ("/home/cam/.cargo/bin/isq", InstallMethod::Cargo),
             // Unknown paths
             ("/some/random/path/isq", InstallMethod::Unknown),
-            ("/Users/cam/src/isq/target/debug/isq", InstallMethod::Unknown),
+            (
+                "/Users/cam/src/isq/target/debug/isq",
+                InstallMethod::Unknown,
+            ),
             ("/usr/local/bin/isq", InstallMethod::Unknown),
         ];
 
@@ -410,8 +421,14 @@ mod tests {
     #[test]
     fn test_detect_from_path_windows() {
         let cases = [
-            (r"C:\Users\cam\scoop\apps\isq\current\isq.exe", InstallMethod::Scoop),
-            (r"C:\Users\Cam\Scoop\Apps\isq\current\isq.exe", InstallMethod::Scoop),
+            (
+                r"C:\Users\cam\scoop\apps\isq\current\isq.exe",
+                InstallMethod::Scoop,
+            ),
+            (
+                r"C:\Users\Cam\Scoop\Apps\isq\current\isq.exe",
+                InstallMethod::Scoop,
+            ),
             (r"C:\Users\cam\.cargo\bin\isq.exe", InstallMethod::Cargo),
         ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,13 +15,19 @@ mod user_config;
 use anyhow::Result;
 use clap::Parser;
 
-use crate::cli::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};
+use crate::cli::{
+    Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands,
+    UpdateCommands, ViewCommands,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Migrate credentials from OS keychain to file storage (one-time, silent on no credentials)
     if let Err(e) = credentials::migrate_from_keyring() {
-        eprintln!("Warning: Failed to migrate credentials from keychain: {}", e);
+        eprintln!(
+            "Warning: Failed to migrate credentials from keychain: {}",
+            e
+        );
     }
 
     let cli = Cli::parse();
@@ -39,9 +45,7 @@ async fn main() -> Result<()> {
 
     match cli.command {
         None => cli::worktree::cmd_home()?,
-        Some(Commands::Link { forge, opt }) => {
-            cli::link::cmd_link(forge.as_deref(), opt).await?
-        }
+        Some(Commands::Link { forge, opt }) => cli::link::cmd_link(forge.as_deref(), opt).await?,
         Some(Commands::Unlink) => cli::link::cmd_unlink()?,
         Some(Commands::Logout { forge }) => cli::link::cmd_logout(forge.as_deref())?,
         Some(Commands::Status) => cli::status::cmd_status()?,
@@ -60,8 +64,10 @@ async fn main() -> Result<()> {
                 opt,
                 json,
             } => {
-                cli::issues::cmd_list(view, id, label, state, all, mine, unassigned, open, goal, sort, opt, json)
-                    .await?
+                cli::issues::cmd_list(
+                    view, id, label, state, all, mine, unassigned, open, goal, sort, opt, json,
+                )
+                .await?
             }
             IssueCommands::Show { id, json } => cli::issues::cmd_show(&id, json)?,
             IssueCommands::Create {
@@ -75,8 +81,12 @@ async fn main() -> Result<()> {
             IssueCommands::Comment { id, message, json } => {
                 cli::issues::cmd_comment(&id, message, json, cli.quiet).await?
             }
-            IssueCommands::Close { id, json } => cli::issues::cmd_close(&id, json, cli.quiet).await?,
-            IssueCommands::Reopen { id, json } => cli::issues::cmd_reopen(&id, json, cli.quiet).await?,
+            IssueCommands::Close { id, json } => {
+                cli::issues::cmd_close(&id, json, cli.quiet).await?
+            }
+            IssueCommands::Reopen { id, json } => {
+                cli::issues::cmd_reopen(&id, json, cli.quiet).await?
+            }
             IssueCommands::Label {
                 id,
                 action,
@@ -108,7 +118,9 @@ async fn main() -> Result<()> {
             GoalCommands::Assign { issue, goal, json } => {
                 cli::goals::cmd_assign(&issue, goal, json, cli.quiet).await?
             }
-            GoalCommands::Close { name, json } => cli::goals::cmd_close(name, json, cli.quiet).await?,
+            GoalCommands::Close { name, json } => {
+                cli::goals::cmd_close(name, json, cli.quiet).await?
+            }
         },
         Some(Commands::Current { quiet }) => cli::worktree::cmd_current(quiet)?,
         Some(Commands::Start { id }) => cli::worktree::cmd_start(id).await?,

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -39,10 +39,7 @@ pub fn print_with_pager(content: &str) {
         cmd.arg("-R");
     }
 
-    match cmd
-        .stdin(Stdio::piped())
-        .spawn()
-    {
+    match cmd.stdin(Stdio::piped()).spawn() {
         Ok(mut child) => {
             if let Some(mut stdin) = child.stdin.take() {
                 let _ = stdin.write_all(content.as_bytes());

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -122,7 +122,9 @@ fn parse_owner_name(path: &str) -> Result<Repo> {
 /// Returns None if HEAD is detached (not on a branch)
 pub fn detect_current_branch() -> Result<Option<String>> {
     let repo = discover_repo()?;
-    let head = repo.head().map_err(|e| anyhow!("Failed to read HEAD: {}", e))?;
+    let head = repo
+        .head()
+        .map_err(|e| anyhow!("Failed to read HEAD: {}", e))?;
     Ok(head.referent_name().map(|n| n.shorten().to_string()))
 }
 
@@ -318,10 +320,7 @@ mod tests {
     fn test_detect_git_dir() {
         // This test runs from within the isq repo
         let git_dir = detect_git_dir().unwrap();
-        assert!(
-            git_dir.ends_with(".git")
-                || git_dir.to_string_lossy().contains(".git/worktrees/")
-        );
+        assert!(git_dir.ends_with(".git") || git_dir.to_string_lossy().contains(".git/worktrees/"));
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
@@ -359,7 +359,12 @@ WantedBy=default.target
 
         // Get service properties
         let output = Command::new("systemctl")
-            .args(["--user", "show", SERVICE_NAME, "--property=ActiveState,MainPID"])
+            .args([
+                "--user",
+                "show",
+                SERVICE_NAME,
+                "--property=ActiveState,MainPID",
+            ])
             .output()?;
 
         if !output.status.success() {
@@ -412,7 +417,9 @@ mod platform {
     }
 
     pub fn install() -> Result<()> {
-        Err(anyhow!("System service not supported on this platform. Use 'isq daemon run' manually."))
+        Err(anyhow!(
+            "System service not supported on this platform. Use 'isq daemon run' manually."
+        ))
     }
 
     pub fn uninstall() -> Result<()> {
@@ -420,7 +427,9 @@ mod platform {
     }
 
     pub fn start() -> Result<()> {
-        Err(anyhow!("System service not supported on this platform. Use 'isq daemon run' manually."))
+        Err(anyhow!(
+            "System service not supported on this platform. Use 'isq daemon run' manually."
+        ))
     }
 
     pub fn stop() -> Result<()> {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,6 +1,6 @@
 //! Update checking and application logic using GitHub Releases API
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use self_update::backends::github::ReleaseList;
 use semver::Version;
 use serde::Serialize;
@@ -27,8 +27,7 @@ pub struct UpdateInfo {
 pub async fn check_for_updates() -> Result<Option<UpdateInfo>> {
     // self_update uses blocking HTTP internally, so we need to run it
     // in a blocking thread to avoid issues with the async runtime
-    tokio::task::spawn_blocking(check_for_updates_blocking)
-        .await?
+    tokio::task::spawn_blocking(check_for_updates_blocking).await?
 }
 
 fn check_for_updates_blocking() -> Result<Option<UpdateInfo>> {
@@ -139,9 +138,98 @@ fn apply_update_blocking() -> Result<UpdateResult> {
     })
 }
 
+/// Parse version from `isq --version` output.
+/// Format: "isq 0.1.0" or "isq 0.1.0 (standalone, auto-updates enabled)"
+fn parse_version_from_output(output: &str) -> Result<String> {
+    let line = output.lines().next().unwrap_or("");
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() >= 2 && parts[0] == "isq" {
+        Ok(parts[1].to_string())
+    } else {
+        anyhow::bail!("Could not parse version from: {}", output)
+    }
+}
+
+/// Get version of the binary on disk by running `isq --version`.
+///
+/// This spawns a subprocess to get the actual compiled-in version of the
+/// binary file, which may differ from our running version if the binary
+/// was updated while we're running.
+pub async fn get_binary_version_on_disk() -> Result<String> {
+    let exe = std::env::current_exe()?;
+    let output = tokio::process::Command::new(&exe)
+        .arg("--version")
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Failed to get binary version: exit code {:?}",
+            output.status.code()
+        );
+    }
+
+    parse_version_from_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Check if running version differs from binary on disk.
+///
+/// Returns true if the disk binary has a different version, indicating
+/// the daemon should restart to pick up the new version.
+pub async fn is_binary_updated() -> Result<bool> {
+    let running = env!("CARGO_PKG_VERSION");
+    let on_disk = get_binary_version_on_disk().await?;
+    Ok(running != on_disk)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_version_from_output() {
+        // Basic format
+        assert_eq!(parse_version_from_output("isq 0.1.0").unwrap(), "0.1.0");
+
+        // With install method suffix
+        assert_eq!(
+            parse_version_from_output("isq 0.2.0 (standalone)").unwrap(),
+            "0.2.0"
+        );
+
+        // With auto-update info
+        assert_eq!(
+            parse_version_from_output("isq 1.0.0 (standalone, auto-updates enabled)").unwrap(),
+            "1.0.0"
+        );
+
+        // With trailing newline
+        assert_eq!(parse_version_from_output("isq 0.1.0\n").unwrap(), "0.1.0");
+
+        // Multi-line output (homebrew includes note)
+        assert_eq!(
+            parse_version_from_output(
+                "isq 0.1.0 (homebrew)\nNote: Run `brew upgrade isq` to update."
+            )
+            .unwrap(),
+            "0.1.0"
+        );
+    }
+
+    #[test]
+    fn test_parse_version_from_output_errors() {
+        // Empty string
+        assert!(parse_version_from_output("").is_err());
+
+        // Wrong prefix
+        assert!(parse_version_from_output("foo 0.1.0").is_err());
+
+        // No version
+        assert!(parse_version_from_output("isq").is_err());
+
+        // Just whitespace
+        assert!(parse_version_from_output("   ").is_err());
+    }
 
     #[test]
     fn test_version_comparison() {


### PR DESCRIPTION
## Summary

- Daemon now checks every 5 minutes if the binary on disk has been updated
- When version mismatch detected, daemon exits gracefully to allow launchd/systemd to restart it
- PID file upgraded to JSON format with version info (`DaemonInfo` struct)
- CLI `isq daemon status` checks and restarts stale daemon as fallback
- Uses `tokio::select!` for concurrent sync and version check intervals

Closes #7

## Test plan

- [ ] Start daemon with `isq daemon start`
- [ ] Verify `~/.cache/isq/daemon.pid` contains JSON with version
- [ ] Run `cargo test` - all tests pass
- [ ] Build new version, replace binary
- [ ] Wait 5 minutes (or check daemon logs for version check)
- [ ] Verify daemon restarts with new version
- [ ] Run `isq daemon status` to trigger CLI fallback check

🤖 Generated with [Claude Code](https://claude.com/claude-code)