### PR TITLE
Add daemon version check and auto-restart

### DIFF
--- a/src/cli/daemon.rs
+++ b/src/cli/daemon.rs
@@ -2,10 +2,40 @@
 
 use anyhow::Result;
 
+use crate::daemon;
 use crate::db;
 use crate::forges::{not_linked_error, ALL_FORGE_TYPES};
 use crate::repo;
 use crate::service;
+
+/// Check if the daemon is running a stale version and restart if needed.
+///
+/// Compares the daemon's version (from PID file) with the current CLI version.
+/// If they differ, restarts the daemon to pick up the new binary.
+///
+/// Returns true if the daemon was restarted.
+pub fn ensure_daemon_current() -> Result<bool> {
+    let current = env!("CARGO_PKG_VERSION");
+
+    let info = match daemon::read_daemon_info()? {
+        Some(i) => i,
+        None => return Ok(false), // No daemon info file
+    };
+
+    // Check if daemon is actually running
+    if !service::status()?.running {
+        return Ok(false);
+    }
+
+    if info.version != current {
+        eprintln!("Restarting daemon (v{} -> v{})...", info.version, current);
+        service::stop()?;
+        service::start()?;
+        return Ok(true);
+    }
+
+    Ok(false)
+}
 
 pub fn cmd_status() -> Result<()> {
     // Check service status

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use futures::stream::{self, StreamExt};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::{self, File};
-use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -19,6 +19,15 @@ const MAX_BACKOFF_SECS: u64 = 3600; // Max 1 hour backoff
 const FULL_SYNC_INTERVAL_HOURS: i64 = 1; // Hours between full reconciliation syncs
 const MAX_CONCURRENT_SYNCS: usize = 4; // Max repos to sync in parallel
 const FULL_SYNC_RETRY_COOLDOWN_MINS: i64 = 15; // Minutes to wait after failed full sync attempt
+const VERSION_CHECK_INTERVAL_SECS: u64 = 300; // 5 minutes - check if binary was updated
+
+/// Information about the running daemon, stored in the PID file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonInfo {
+    pub pid: u32,
+    pub version: String,
+    pub started_at: DateTime<Utc>,
+}
 
 /// Get the daemon PID file path
 pub fn pid_path() -> Result<PathBuf> {
@@ -70,6 +79,28 @@ fn acquire_lock() -> Result<File> {
     Ok(File::create(&path)?)
 }
 
+/// Write daemon info to the PID file in JSON format.
+fn write_daemon_info(info: &DaemonInfo) -> Result<()> {
+    let pid_file = pid_path()?;
+    let content = serde_json::to_string_pretty(info)?;
+    fs::write(&pid_file, content)?;
+    Ok(())
+}
+
+/// Read daemon info from the PID file.
+///
+/// Returns None if file doesn't exist or is invalid JSON.
+pub fn read_daemon_info() -> Result<Option<DaemonInfo>> {
+    let pid_file = pid_path()?;
+
+    if !pid_file.exists() {
+        return Ok(None);
+    }
+
+    let content = fs::read_to_string(&pid_file)?;
+    Ok(serde_json::from_str(&content).ok())
+}
+
 /// Per-repo sync state for backoff tracking
 struct RepoSyncState {
     consecutive_failures: u32,
@@ -104,18 +135,27 @@ fn calculate_backoff(failures: u32) -> Duration {
 /// Repos are sorted by last_accessed (most recent first) so that if we can't
 /// finish all repos before the next cycle (due to rate limits or too many repos),
 /// the ones you're actively using get priority.
+///
+/// Also checks every VERSION_CHECK_INTERVAL_SECS if the binary on disk has been
+/// updated, and exits gracefully to allow the service manager to restart with
+/// the new version.
 pub async fn run_loop() -> Result<()> {
     // Acquire exclusive lock FIRST - prevents multiple instances
     let _lock = acquire_lock()?;
     eprintln!("[daemon] Acquired exclusive lock");
 
-    // Write PID file after acquiring lock
-    let pid_file = pid_path()?;
-    let mut f = File::create(&pid_file)?;
-    writeln!(f, "{}", std::process::id())?;
-    drop(f);
+    // Write daemon info (JSON format with version)
+    let daemon_info = DaemonInfo {
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        started_at: Utc::now(),
+    };
+    write_daemon_info(&daemon_info)?;
 
-    eprintln!("[daemon] Starting sync loop (interval: {}s)", SYNC_INTERVAL_SECS);
+    eprintln!(
+        "[daemon] Starting sync loop (sync: {}s, version check: {}s)",
+        SYNC_INTERVAL_SECS, VERSION_CHECK_INTERVAL_SECS
+    );
 
     // Clean up stale repo entries on startup
     if let Ok(conn) = db::open() {
@@ -130,92 +170,128 @@ pub async fn run_loop() -> Result<()> {
     let repo_states: Arc<Mutex<HashMap<String, RepoSyncState>>> =
         Arc::new(Mutex::new(HashMap::new()));
 
+    // Create intervals for sync and version check
+    let mut sync_interval = tokio::time::interval(Duration::from_secs(SYNC_INTERVAL_SECS));
+    let mut version_interval = tokio::time::interval(Duration::from_secs(VERSION_CHECK_INTERVAL_SECS));
+
+    // Skip the first immediate tick for version check (don't check on startup)
+    version_interval.tick().await;
+
     loop {
-        let conn = db::open()?;
-        let watched = db::list_watched_repos(&conn)?;
-        // list_watched_repos already returns sorted by last_accessed DESC
-
-        if watched.is_empty() {
-            eprintln!("[daemon] No repos to watch, waiting...");
-        } else {
-            let now = Instant::now();
-
-            // Sync repos in parallel with bounded concurrency
-            let results: Vec<(String, SyncResult)> = stream::iter(watched.iter())
-                .map(|repo| {
-                    let states = Arc::clone(&repo_states);
-                    let repo_path = repo.repo.clone();
-                    async move {
-                        // Check if this repo is in backoff
-                        {
-                            let states = states.lock().await;
-                            if let Some(state) = states.get(&repo_path) {
-                                if Instant::now() < state.next_attempt {
-                                    return (repo_path, SyncResult::Skipped);
-                                }
-                            }
-                        }
-
-                        // Sync the repo
-                        match sync_once(&repo_path).await {
-                            Ok(()) => (repo_path, SyncResult::Success),
-                            Err(e) => (repo_path, SyncResult::Error(e)),
-                        }
+        tokio::select! {
+            _ = sync_interval.tick() => {
+                perform_sync_cycle(&repo_states).await;
+            }
+            _ = version_interval.tick() => {
+                match crate::updater::is_binary_updated().await {
+                    Ok(true) => {
+                        eprintln!("[daemon] Binary updated, exiting for restart...");
+                        return Ok(()); // Service manager will restart us
                     }
-                })
-                .buffer_unordered(MAX_CONCURRENT_SYNCS)
-                .collect()
-                .await;
-
-            // Update backoff states based on results
-            let mut synced = 0;
-            let mut skipped = 0;
-            {
-                let mut states = repo_states.lock().await;
-                for (repo_path, result) in results {
-                    match result {
-                        SyncResult::Success => {
-                            states.remove(&repo_path);
-                            synced += 1;
-                        }
-                        SyncResult::Skipped => {
-                            skipped += 1;
-                        }
-                        SyncResult::Error(e) => {
-                            eprintln!("[daemon] Sync error for {}: {}", repo_path, e);
-
-                            let state =
-                                states.entry(repo_path.clone()).or_insert(RepoSyncState {
-                                    consecutive_failures: 0,
-                                    next_attempt: now,
-                                });
-                            state.consecutive_failures += 1;
-                            let backoff = calculate_backoff(state.consecutive_failures);
-                            state.next_attempt = now + backoff;
-
-                            eprintln!(
-                                "[daemon] {} in backoff for {:.0}s (failures: {})",
-                                repo_path,
-                                backoff.as_secs_f64(),
-                                state.consecutive_failures
-                            );
-                        }
+                    Ok(false) => {} // Same version, continue
+                    Err(e) => {
+                        eprintln!("[daemon] Version check failed: {} (continuing)", e);
                     }
                 }
             }
+        }
+    }
+}
 
-            if synced > 0 || skipped > 0 {
-                eprintln!(
-                    "[daemon] Cycle complete: {} synced, {} in backoff",
-                    synced, skipped
-                );
+/// Perform a single sync cycle for all watched repos.
+async fn perform_sync_cycle(repo_states: &Arc<Mutex<HashMap<String, RepoSyncState>>>) {
+    let conn = match db::open() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[daemon] Failed to open database: {}", e);
+            return;
+        }
+    };
+
+    let watched = match db::list_watched_repos(&conn) {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!("[daemon] Failed to list watched repos: {}", e);
+            return;
+        }
+    };
+
+    if watched.is_empty() {
+        eprintln!("[daemon] No repos to watch, waiting...");
+        return;
+    }
+
+    let now = Instant::now();
+
+    // Sync repos in parallel with bounded concurrency
+    let results: Vec<(String, SyncResult)> = stream::iter(watched.iter())
+        .map(|repo| {
+            let states = Arc::clone(repo_states);
+            let repo_path = repo.repo.clone();
+            async move {
+                // Check if this repo is in backoff
+                {
+                    let states = states.lock().await;
+                    if let Some(state) = states.get(&repo_path) {
+                        if Instant::now() < state.next_attempt {
+                            return (repo_path, SyncResult::Skipped);
+                        }
+                    }
+                }
+
+                // Sync the repo
+                match sync_once(&repo_path).await {
+                    Ok(()) => (repo_path, SyncResult::Success),
+                    Err(e) => (repo_path, SyncResult::Error(e)),
+                }
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_SYNCS)
+        .collect()
+        .await;
+
+    // Update backoff states based on results
+    let mut synced = 0;
+    let mut skipped = 0;
+    {
+        let mut states = repo_states.lock().await;
+        for (repo_path, result) in results {
+            match result {
+                SyncResult::Success => {
+                    states.remove(&repo_path);
+                    synced += 1;
+                }
+                SyncResult::Skipped => {
+                    skipped += 1;
+                }
+                SyncResult::Error(e) => {
+                    eprintln!("[daemon] Sync error for {}: {}", repo_path, e);
+
+                    let state =
+                        states.entry(repo_path.clone()).or_insert(RepoSyncState {
+                            consecutive_failures: 0,
+                            next_attempt: now,
+                        });
+                    state.consecutive_failures += 1;
+                    let backoff = calculate_backoff(state.consecutive_failures);
+                    state.next_attempt = now + backoff;
+
+                    eprintln!(
+                        "[daemon] {} in backoff for {:.0}s (failures: {})",
+                        repo_path,
+                        backoff.as_secs_f64(),
+                        state.consecutive_failures
+                    );
+                }
             }
         }
+    }
 
-        // Add jitter to sleep interval to prevent synchronized requests
-        let jitter = (rand::random::<f64>() - 0.5) * 0.2; // ±10%
-        let sleep_secs = SYNC_INTERVAL_SECS as f64 * (1.0 + jitter);
-        tokio::time::sleep(Duration::from_secs_f64(sleep_secs)).await;
+    if synced > 0 || skipped > 0 {
+        eprintln!(
+            "[daemon] Cycle complete: {} synced, {} in backoff",
+            synced, skipped
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,24 @@ use clap::Parser;
 
 use crate::cli::{Cli, Commands, DaemonCommands, GoalCommands, InstallCommands, IssueCommands, LabelCommands, UpdateCommands, ViewCommands};
 
+/// Check if a command depends on the daemon being current.
+fn should_check_daemon_version(command: &Option<Commands>) -> bool {
+    matches!(
+        command,
+        Some(
+            Commands::Daemon {
+                command: DaemonCommands::Status
+                    | DaemonCommands::Start
+                    | DaemonCommands::Watch
+                    | DaemonCommands::Unwatch
+            } | Commands::Sync
+              | Commands::Issue { .. }
+              | Commands::Goal { .. }
+              | Commands::Label { .. }
+        )
+    )
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Migrate credentials from OS keychain to file storage (one-time, silent on no credentials)
@@ -35,6 +53,13 @@ async fn main() -> Result<()> {
     if cli.version {
         cli::print_version();
         return Ok(());
+    }
+
+    // Check if daemon needs restart for new version before running daemon-dependent commands
+    if should_check_daemon_version(&cli.command)
+        && let Ok(true) = cli::daemon::ensure_daemon_current()
+    {
+        eprintln!("Daemon restarted for new version");
     }
 
     match cli.command {

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -139,6 +139,58 @@ fn apply_update_blocking() -> Result<UpdateResult> {
     })
 }
 
+/// Parse version from `isq --version` output.
+/// Format: "isq 0.1.0" or "isq 0.1.0 (standalone, auto-updates enabled)"
+fn parse_version_from_output(output: &str) -> Result<String> {
+    let line = output.lines().next().unwrap_or("");
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() >= 2 && parts[0] == "isq" {
+        Ok(parts[1].to_string())
+    } else {
+        anyhow::bail!("Could not parse version from: {}", output)
+    }
+}
+
+/// Get version of the binary on disk by running `isq --version`.
+///
+/// This spawns a subprocess to get the actual compiled-in version of the
+/// binary file, which may differ from our running version if the binary
+/// was updated while we're running.
+///
+/// Includes a 5-second timeout to prevent hanging if the subprocess gets stuck.
+pub async fn get_binary_version_on_disk() -> Result<String> {
+    use std::time::Duration;
+
+    let exe = std::env::current_exe()?;
+    let output = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::process::Command::new(&exe)
+            .arg("--version")
+            .output(),
+    )
+    .await
+    .map_err(|_| anyhow!("Version check timed out after 5 seconds"))??;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Failed to get binary version: exit code {:?}",
+            output.status.code()
+        );
+    }
+
+    parse_version_from_output(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Check if running version differs from binary on disk.
+///
+/// Returns true if the disk binary has a different version, indicating
+/// the daemon should restart to pick up the new version.
+pub async fn is_binary_updated() -> Result<bool> {
+    let running = env!("CARGO_PKG_VERSION");
+    let on_disk = get_binary_version_on_disk().await?;
+    Ok(running != on_disk)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -164,5 +216,50 @@ mod tests {
         assert!("0.2.0-rc.1".contains('-'));
         assert!(!"0.2.0".contains('-'));
         assert!(!"1.0.0".contains('-'));
+    }
+
+    #[test]
+    fn test_parse_version_from_output() {
+        // Basic format
+        assert_eq!(parse_version_from_output("isq 0.1.0").unwrap(), "0.1.0");
+
+        // With install method suffix
+        assert_eq!(
+            parse_version_from_output("isq 0.2.0 (standalone)").unwrap(),
+            "0.2.0"
+        );
+
+        // With auto-update info
+        assert_eq!(
+            parse_version_from_output("isq 1.0.0 (standalone, auto-updates enabled)").unwrap(),
+            "1.0.0"
+        );
+
+        // With trailing newline
+        assert_eq!(parse_version_from_output("isq 0.1.0\n").unwrap(), "0.1.0");
+
+        // Multi-line output (homebrew includes note)
+        assert_eq!(
+            parse_version_from_output(
+                "isq 0.1.0 (homebrew)\nNote: Run `brew upgrade isq` to update."
+            )
+            .unwrap(),
+            "0.1.0"
+        );
+    }
+
+    #[test]
+    fn test_parse_version_from_output_errors() {
+        // Empty string
+        assert!(parse_version_from_output("").is_err());
+
+        // Wrong prefix
+        assert!(parse_version_from_output("foo 0.1.0").is_err());
+
+        // No version
+        assert!(parse_version_from_output("isq").is_err());
+
+        // Just whitespace
+        assert!(parse_version_from_output("   ").is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Daemon checks every 5 minutes if the binary on disk has been updated
- When version mismatch detected, daemon exits gracefully to allow launchd/systemd to restart it
- PID file upgraded to JSON format with version info (`DaemonInfo` struct)
- CLI checks and restarts stale daemon before daemon-dependent commands (issue, goal, label, sync, daemon status/start/watch/unwatch)
- Uses `tokio::select!` for concurrent sync and version check intervals
- Version check includes 5-second timeout to prevent hanging

Closes #7

## Changes

- `src/daemon.rs` - Added `DaemonInfo` struct, `write_daemon_info()`, `read_daemon_info()`, restructured `run_loop()` with `tokio::select!`
- `src/updater.rs` - Added `parse_version_from_output()`, `get_binary_version_on_disk()`, `is_binary_updated()` with tests
- `src/cli/daemon.rs` - Added `ensure_daemon_current()` function
- `src/main.rs` - Added `should_check_daemon_version()` and call to `ensure_daemon_current()` before relevant commands

## Test plan

- [ ] Start daemon with `isq daemon start`
- [ ] Verify `~/.cache/isq/daemon.pid` contains JSON with version
- [ ] Run `cargo test` - all tests pass
- [ ] Build new version, replace binary
- [ ] Wait 5 minutes (or check daemon logs for version check)
- [ ] Verify daemon restarts with new version
- [ ] Run `isq issue list` to trigger CLI fallback check

🤖 Generated with [Claude Code](https://claude.com/claude-code)