### PR TITLE
Modularize github/mod.rs into submodules for maintainability

### DIFF
--- a/src/forges/github/link.rs
+++ b/src/forges/github/link.rs
@@ -1,0 +1,86 @@
+//! GitHub repository linking flow
+//!
+//! Handles authentication, verification, issue sync, and database setup.
+
+use anyhow::Result;
+
+use super::AUTH;
+use super::client::GitHubClient;
+use super::oauth::oauth_flow;
+use crate::forges::{ForgeType, LinkArgs, LinkResult};
+use crate::{config, db, repo};
+
+/// Run the complete GitHub link flow.
+/// Handles auth, verifies credentials, syncs issues, and returns the result.
+pub async fn link(repo_path: &str, _args: &LinkArgs) -> Result<LinkResult> {
+    let forge_type = ForgeType::GitHub;
+    let conn = db::open()?;
+
+    // Detect GitHub repo from git remote
+    let repo = repo::detect_repo()?;
+
+    // Try existing auth first, fall back to OAuth
+    let (token, auth_method) = match AUTH.get_token() {
+        Ok(t) => {
+            // Store in keychain so daemon can access
+            // (gh CLI isn't available from launchd)
+            AUTH.store_credential(&t, None, None)?;
+            (t, "existing")
+        }
+        Err(_) => {
+            let oauth_token = oauth_flow().await?;
+            AUTH.store_credential(
+                &oauth_token.access_token,
+                oauth_token.refresh_token.as_deref(),
+                None, // GitHub tokens don't expire by default
+            )?;
+            (oauth_token.access_token, "OAuth")
+        }
+    };
+
+    let client = GitHubClient::new(token);
+
+    // Verify authentication
+    let username = client.get_user().await?;
+    println!("✓ Authenticated as {} (via {})", username, auth_method);
+
+    // Sync issues
+    let display_name = repo.full_name();
+    println!("Syncing {}...", display_name);
+    let issues_result = client.list_issues_internal(&repo, None).await?;
+
+    // Save to database (for GitHub, username serves as both user_id and user_name)
+    db::set_repo_link(
+        &conn,
+        repo_path,
+        forge_type.as_str(),
+        &repo.full_name(),
+        Some(&display_name),
+        Some(&username),
+        Some(&username),
+    )?;
+    db::save_issues(
+        &conn,
+        &repo.full_name(),
+        &issues_result.items,
+        true,
+        issues_result.is_complete,
+    )?;
+    db::add_watched_repo(&conn, repo_path)?;
+
+    // Create .config/isq.toml with defaults
+    if config::create_repo_config(std::path::Path::new(repo_path), forge_type.as_str())? {
+        println!("✓ Created .config/isq.toml");
+    }
+
+    // Install commit hook
+    match repo::install_hook(std::path::Path::new(repo_path)) {
+        Ok(true) => println!("✓ Installed commit hook"),
+        Ok(false) => {} // Already installed, silent
+        Err(e) => eprintln!("Warning: Could not install hook: {}", e),
+    }
+
+    println!("✓ Cached {} issues", issues_result.items.len());
+
+    Ok(LinkResult { display_name })
+}

--- a/src/forges/github/mod.rs
+++ b/src/forges/github/mod.rs
@@ -5,11 +5,16 @@
 pub mod client;
 mod comments;
 mod labels;
+mod link;
 mod milestones;
 mod mutations;
 pub mod oauth;
+mod priority;
 pub mod rate_limit;
 pub mod types;
+
+#[cfg(test)]
+mod tests;
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -17,14 +22,13 @@ use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
 use crate::forges::{
-    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, ForgeType, Goal, Issue,
-    Label, LinkArgs, LinkResult, RateLimitInfo,
+    AuthConfig, CreateGoalRequest, CreateIssueRequest, FetchResult, Forge, Goal, Issue, Label,
+    RateLimitInfo,
 };
 use crate::repo::Repo;
-use crate::{config, db, repo};
 
 pub use client::GitHubClient;
-pub use oauth::oauth_flow;
+pub use link::link;
 
 // ============================================================================
 // Auth Configuration
@@ -68,139 +72,6 @@ struct GitHubOnCleanupConfig {
     /// Labels to remove from the issue
     #[serde(default)]
     remove_labels: Vec<String>,
-}
-
-// ============================================================================
-// Link Flow
-// ============================================================================
-
-/// Run the complete GitHub link flow.
-/// Handles auth, verifies credentials, syncs issues, and returns the result.
-pub async fn link(repo_path: &str, _args: &LinkArgs) -> Result<LinkResult> {
-    let forge_type = ForgeType::GitHub;
-    let conn = db::open()?;
-
-    // Detect GitHub repo from git remote
-    let repo = repo::detect_repo()?;
-
-    // Try existing auth first, fall back to OAuth
-    let (token, auth_method) = match AUTH.get_token() {
-        Ok(t) => {
-            // Store in keychain so daemon can access
-            // (gh CLI isn't available from launchd)
-            AUTH.store_credential(&t, None, None)?;
-            (t, "existing")
-        }
-        Err(_) => {
-            let oauth_token = oauth_flow().await?;
-            AUTH.store_credential(
-                &oauth_token.access_token,
-                oauth_token.refresh_token.as_deref(),
-                None, // GitHub tokens don't expire by default
-            )?;
-            (oauth_token.access_token, "OAuth")
-        }
-    };
-
-    let client = GitHubClient::new(token);
-
-    // Verify authentication
-    let username = client.get_user().await?;
-    println!("✓ Authenticated as {} (via {})", username, auth_method);
-
-    // Sync issues
-    let display_name = repo.full_name();
-    println!("Syncing {}...", display_name);
-    let issues_result = client.list_issues_internal(&repo, None).await?;
-
-    // Save to database (for GitHub, username serves as both user_id and user_name)
-    db::set_repo_link(
-        &conn,
-        repo_path,
-        forge_type.as_str(),
-        &repo.full_name(),
-        Some(&display_name),
-        Some(&username),
-        Some(&username),
-    )?;
-    db::save_issues(
-        &conn,
-        &repo.full_name(),
-        &issues_result.items,
-        true,
-        issues_result.is_complete,
-    )?;
-    db::add_watched_repo(&conn, repo_path)?;
-
-    // Create .config/isq.toml with defaults
-    if config::create_repo_config(std::path::Path::new(repo_path), forge_type.as_str())? {
-        println!("✓ Created .config/isq.toml");
-    }
-
-    // Install commit hook
-    match repo::install_hook(std::path::Path::new(repo_path)) {
-        Ok(true) => println!("✓ Installed commit hook"),
-        Ok(false) => {} // Already installed, silent
-        Err(e) => eprintln!("Warning: Could not install hook: {}", e),
-    }
-
-    println!("✓ Cached {} issues", issues_result.items.len());
-
-    Ok(LinkResult { display_name })
-}
-
-// ============================================================================
-// Priority Configuration
-// ============================================================================
-
-/// Apply priority from label configuration to issues.
-/// This is a pure function extracted for testability.
-fn apply_priority_from_labels(issues: &mut [Issue], config: &toml::Value) {
-    // Parse priority config: { "P0" = 0, "bug" = 1, ... }
-    let priority_labels: std::collections::HashMap<String, u8> = config
-        .as_table()
-        .map(|table| {
-            table
-                .iter()
-                .filter_map(|(label, value)| {
-                    let priority = value.as_integer()?;
-                    if (0..=4).contains(&priority) {
-                        Some((label.clone(), priority as u8))
-                    } else {
-                        None
-                    }
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if priority_labels.is_empty() {
-        return;
-    }
-
-    // Apply priority from labels to issues
-    for issue in issues.iter_mut() {
-        // Only apply if priority hasn't been set (default is 4/none)
-        if issue.priority == 4 {
-            // Find the highest priority label (lowest number)
-            let mut best_priority = 4u8;
-            let mut best_label: Option<String> = None;
-
-            for label in &issue.labels {
-                if let Some(&priority) = priority_labels.get(&label.name)
-                    && priority < best_priority
-                {
-                    best_priority = priority;
-                    best_label = Some(label.name.clone());
-                }
-            }
-
-            if best_priority < 4 {
-                issue.priority = best_priority;
-                issue.priority_label = best_label;
-            }
-        }
-    }
 }
 
 // ============================================================================
@@ -442,116 +313,6 @@ impl Forge for GitHubClient {
     }
 
     fn apply_priority_config(&self, issues: &mut [Issue], config: &toml::Value) {
-        apply_priority_from_labels(issues, config);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn make_issue(id: &str, labels: Vec<&str>) -> Issue {
-        Issue {
-            id: id.to_string(),
-            title: format!("Issue {}", id),
-            body: None,
-            state: "open".to_string(),
-            author: "testuser".to_string(),
-            labels: labels
-                .into_iter()
-                .map(|s| Label::name_only(s.to_string()))
-                .collect(),
-            assignees: vec![],
-            priority: 4, // Default: none
-            priority_label: None,
-            created_at: "2024-01-01T00:00:00Z".to_string(),
-            updated_at: "2024-01-01T00:00:00Z".to_string(),
-            url: None,
-            milestone: None,
-        }
-    }
-
-    #[test]
-    fn test_apply_priority_from_labels() {
-        let config: toml::Value = toml::from_str(
-            r#"
-            P0 = 0
-            P1 = 1
-            P2 = 2
-        "#,
-        )
-        .unwrap();
-
-        let mut issues = vec![make_issue("1", vec!["P0", "bug"])];
-        apply_priority_from_labels(&mut issues, &config);
-
-        assert_eq!(issues[0].priority, 0);
-        assert_eq!(issues[0].priority_label, Some("P0".to_string()));
-    }
-
-    #[test]
-    fn test_priority_uses_lowest_value() {
-        let config: toml::Value = toml::from_str(
-            r#"
-            P0 = 0
-            P1 = 1
-        "#,
-        )
-        .unwrap();
-
-        // Issue has both P1 (priority 1) and P0 (priority 0) - should pick P0
-        let mut issues = vec![make_issue("1", vec!["P1", "P0"])];
-        apply_priority_from_labels(&mut issues, &config);
-
-        assert_eq!(issues[0].priority, 0);
-        assert_eq!(issues[0].priority_label, Some("P0".to_string()));
-    }
-
-    #[test]
-    fn test_priority_no_matching_labels() {
-        let config: toml::Value = toml::from_str(
-            r#"
-            P0 = 0
-            P1 = 1
-        "#,
-        )
-        .unwrap();
-
-        let mut issues = vec![make_issue("1", vec!["bug", "enhancement"])];
-        apply_priority_from_labels(&mut issues, &config);
-
-        // Should remain at default priority
-        assert_eq!(issues[0].priority, 4);
-        assert_eq!(issues[0].priority_label, None);
-    }
-
-    #[test]
-    fn test_priority_empty_config() {
-        let config: toml::Value = toml::from_str("").unwrap();
-
-        let mut issues = vec![make_issue("1", vec!["P0"])];
-        apply_priority_from_labels(&mut issues, &config);
-
-        // No config means no priority mapping
-        assert_eq!(issues[0].priority, 4);
-    }
-
-    #[test]
-    fn test_priority_invalid_config_values() {
-        let config: toml::Value = toml::from_str(
-            r#"
-            P0 = 0
-            bad = 99
-            negative = -1
-        "#,
-        )
-        .unwrap();
-
-        // P0 should work, but bad/negative should be ignored
-        let mut issues = vec![make_issue("1", vec!["P0"]), make_issue("2", vec!["bad"])];
-        apply_priority_from_labels(&mut issues, &config);
-
-        assert_eq!(issues[0].priority, 0); // P0 works
-        assert_eq!(issues[1].priority, 4); // bad value ignored
+        priority::apply_priority_from_labels(issues, config);
     }
 }

--- a/src/forges/github/priority.rs
+++ b/src/forges/github/priority.rs
@@ -1,0 +1,55 @@
+//! Priority configuration from labels
+//!
+//! Maps GitHub labels to priority levels based on repo configuration.
+
+use crate::forges::Issue;
+
+/// Apply priority from label configuration to issues.
+/// This is a pure function extracted for testability.
+pub fn apply_priority_from_labels(issues: &mut [Issue], config: &toml::Value) {
+    // Parse priority config: { "P0" = 0, "bug" = 1, ... }
+    let priority_labels: std::collections::HashMap<String, u8> = config
+        .as_table()
+        .map(|table| {
+            table
+                .iter()
+                .filter_map(|(label, value)| {
+                    let priority = value.as_integer()?;
+                    if (0..=4).contains(&priority) {
+                        Some((label.clone(), priority as u8))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if priority_labels.is_empty() {
+        return;
+    }
+
+    // Apply priority from labels to issues
+    for issue in issues.iter_mut() {
+        // Only apply if priority hasn't been set (default is 4/none)
+        if issue.priority == 4 {
+            // Find the highest priority label (lowest number)
+            let mut best_priority = 4u8;
+            let mut best_label: Option<String> = None;
+
+            for label in &issue.labels {
+                if let Some(&priority) = priority_labels.get(&label.name)
+                    && priority < best_priority
+                {
+                    best_priority = priority;
+                    best_label = Some(label.name.clone());
+                }
+            }
+
+            if best_priority < 4 {
+                issue.priority = best_priority;
+                issue.priority_label = best_label;
+            }
+        }
+    }
+}

--- a/src/forges/github/tests.rs
+++ b/src/forges/github/tests.rs
@@ -1,0 +1,109 @@
+//! Unit tests for GitHub module
+
+use super::priority::apply_priority_from_labels;
+use crate::forges::{Issue, Label};
+
+fn make_issue(id: &str, labels: Vec<&str>) -> Issue {
+    Issue {
+        id: id.to_string(),
+        title: format!("Issue {}", id),
+        body: None,
+        state: "open".to_string(),
+        author: "testuser".to_string(),
+        labels: labels
+            .into_iter()
+            .map(|s| Label::name_only(s.to_string()))
+            .collect(),
+        assignees: vec![],
+        priority: 4, // Default: none
+        priority_label: None,
+        created_at: "2024-01-01T00:00:00Z".to_string(),
+        updated_at: "2024-01-01T00:00:00Z".to_string(),
+        url: None,
+        milestone: None,
+    }
+}
+
+#[test]
+fn test_apply_priority_from_labels() {
+    let config: toml::Value = toml::from_str(
+        r#"
+            P0 = 0
+            P1 = 1
+            P2 = 2
+        "#,
+    )
+    .unwrap();
+
+    let mut issues = vec![make_issue("1", vec!["P0", "bug"])];
+    apply_priority_from_labels(&mut issues, &config);
+
+    assert_eq!(issues[0].priority, 0);
+    assert_eq!(issues[0].priority_label, Some("P0".to_string()));
+}
+
+#[test]
+fn test_priority_uses_lowest_value() {
+    let config: toml::Value = toml::from_str(
+        r#"
+            P0 = 0
+            P1 = 1
+        "#,
+    )
+    .unwrap();
+
+    // Issue has both P1 (priority 1) and P0 (priority 0) - should pick P0
+    let mut issues = vec![make_issue("1", vec!["P1", "P0"])];
+    apply_priority_from_labels(&mut issues, &config);
+
+    assert_eq!(issues[0].priority, 0);
+    assert_eq!(issues[0].priority_label, Some("P0".to_string()));
+}
+
+#[test]
+fn test_priority_no_matching_labels() {
+    let config: toml::Value = toml::from_str(
+        r#"
+            P0 = 0
+            P1 = 1
+        "#,
+    )
+    .unwrap();
+
+    let mut issues = vec![make_issue("1", vec!["bug", "enhancement"])];
+    apply_priority_from_labels(&mut issues, &config);
+
+    // Should remain at default priority
+    assert_eq!(issues[0].priority, 4);
+    assert_eq!(issues[0].priority_label, None);
+}
+
+#[test]
+fn test_priority_empty_config() {
+    let config: toml::Value = toml::from_str("").unwrap();
+
+    let mut issues = vec![make_issue("1", vec!["P0"])];
+    apply_priority_from_labels(&mut issues, &config);
+
+    // No config means no priority mapping
+    assert_eq!(issues[0].priority, 4);
+}
+
+#[test]
+fn test_priority_invalid_config_values() {
+    let config: toml::Value = toml::from_str(
+        r#"
+            P0 = 0
+            bad = 99
+            negative = -1
+        "#,
+    )
+    .unwrap();
+
+    // P0 should work, but bad/negative should be ignored
+    let mut issues = vec![make_issue("1", vec!["P0"]), make_issue("2", vec!["bad"])];
+    apply_priority_from_labels(&mut issues, &config);
+
+    assert_eq!(issues[0].priority, 0); // P0 works
+    assert_eq!(issues[1].priority, 4); // bad value ignored
+}


### PR DESCRIPTION
Extract link flow, priority configuration, and tests into separate
submodules to reduce mod.rs from 557 to 318 lines, meeting the 500-line
file size constraint.