### PR TITLE
Add sync health status to isq status output

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Result;
 
-use crate::db;
+use crate::db::{self, SyncHealth};
 use crate::forges::ALL_FORGE_TYPES;
 use crate::repo;
 use crate::service;
@@ -21,6 +21,10 @@ pub fn cmd_status() -> Result<()> {
         }
     }
 
+    // Service status (get early for health check)
+    let svc_status = service::status()?;
+    let daemon_running = svc_status.pid.is_some();
+
     // Current repo link (if in a git repo)
     println!();
     match repo::detect_repo_path() {
@@ -32,10 +36,22 @@ pub fn cmd_status() -> Result<()> {
                     println!("This repo:");
                     println!("  Linked to {} ({})", display, link.forge_type);
 
+                    // Get sync and rate limit state for health calculation
+                    let sync_state = db::get_sync_state(&conn, &link.forge_repo)?;
+                    let rate_limit_state = db::get_rate_limit_state(&conn, &link.forge_type)?;
+
                     // Show sync state
-                    if let Some(sync_state) = db::get_sync_state(&conn, &link.forge_repo)? {
-                        let last_sync = sync_state.last_sync.as_deref().unwrap_or("never");
-                        println!("  {} issues cached ({})", sync_state.issue_count, last_sync);
+                    if let Some(ref state) = sync_state {
+                        let last_sync = state
+                            .last_full_sync_at
+                            .as_deref()
+                            .or(state.issues_last_sync.as_deref())
+                            .or(state.last_sync.as_deref())
+                            .unwrap_or("never");
+                        println!(
+                            "  {} issues cached (last sync: {})",
+                            state.issue_count, last_sync
+                        );
                     }
 
                     // Show pending ops
@@ -44,25 +60,24 @@ pub fn cmd_status() -> Result<()> {
                         println!("  {} pending operations", pending);
                     }
 
-                    // Show rate limit status
-                    if let Some(state) = db::get_rate_limit_state(&conn, &link.forge_type)?
-                        && let Some(reset_at) = state.reset_at
-                    {
-                        let now = std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
-                            .as_secs() as i64;
-                        if now < reset_at {
-                            let wait_secs = reset_at - now;
-                            // Convert to local time, 12-hour format like macOS default
-                            let reset_time = chrono::DateTime::from_timestamp(reset_at, 0)
-                                .map(|dt| {
-                                    use chrono::Local;
-                                    let local: chrono::DateTime<Local> = dt.into();
-                                    local.format("%-I:%M %p").to_string()
-                                })
-                                .unwrap_or_else(|| format!("{}s", wait_secs));
-                            println!("  ⚠️  Rate limited until {}", reset_time);
+                    // Calculate and display sync health
+                    let health = db::calculate_sync_health(
+                        sync_state.as_ref(),
+                        rate_limit_state.as_ref(),
+                        daemon_running,
+                    );
+
+                    match health {
+                        SyncHealth::Healthy => {
+                            println!("  Sync: healthy");
+                        }
+                        SyncHealth::Degraded { reason, guidance } => {
+                            println!("  Sync: degraded - {}", reason);
+                            println!("        {}", guidance);
+                        }
+                        SyncHealth::Unhealthy { reason, guidance } => {
+                            println!("  Sync: unhealthy - {}", reason);
+                            println!("        {}", guidance);
                         }
                     }
                 }
@@ -80,7 +95,6 @@ pub fn cmd_status() -> Result<()> {
     // Service status
     println!();
     print!("Service:    ");
-    let svc_status = service::status()?;
     if !svc_status.installed {
         println!("not installed");
     } else if let Some(pid) = svc_status.pid {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -44,8 +44,8 @@ pub use repos::{
 
 // From sync_state
 pub use sync_state::{
-    PendingOp, SyncState, complete_op, count_pending_ops, get_sync_state, load_pending_ops,
-    purge_deleted_items, queue_op,
+    PendingOp, SyncHealth, SyncState, calculate_sync_health, complete_op, count_pending_ops,
+    get_sync_state, load_pending_ops, purge_deleted_items, queue_op,
 };
 
 /// Result of a sync operation with insert/update/delete counts

--- a/src/db/sync_state.rs
+++ b/src/db/sync_state.rs
@@ -1,7 +1,29 @@
 //! Sync state and pending operations management
 
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use rusqlite::{Connection, params};
+
+use crate::db::rate_limit::RateLimitState;
+
+/// Sync health status for a repository
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SyncHealth {
+    /// Sync is working normally
+    Healthy,
+    /// Sync has issues but data may still be usable
+    Degraded { reason: String, guidance: String },
+    /// Sync is failing
+    Unhealthy { reason: String, guidance: String },
+}
+
+impl SyncHealth {
+    /// Check if this health status indicates a problem
+    #[allow(dead_code)] // Will be used for programmatic checks
+    pub fn has_problem(&self) -> bool {
+        !matches!(self, SyncHealth::Healthy)
+    }
+}
 
 /// Sync state for a repository with per-type cursors
 #[derive(Debug, Clone, Default)]
@@ -126,6 +148,99 @@ pub fn purge_deleted_items(conn: &Connection, ttl_days: i64) -> Result<(usize, u
     )?;
 
     Ok((issues, comments))
+}
+
+/// Thresholds for sync health evaluation
+const STALE_SYNC_MINUTES: i64 = 30;
+const VERY_STALE_SYNC_MINUTES: i64 = 120;
+
+/// Calculate sync health for a repository
+pub fn calculate_sync_health(
+    sync_state: Option<&SyncState>,
+    rate_limit_state: Option<&RateLimitState>,
+    daemon_running: bool,
+) -> SyncHealth {
+    let now = Utc::now();
+
+    // Check rate limit first (most actionable)
+    if let Some(rl) = rate_limit_state
+        && let Some(reset_at) = rl.reset_at
+    {
+        let now_ts = now.timestamp();
+        if now_ts < reset_at {
+            let reset_time = DateTime::from_timestamp(reset_at, 0)
+                .map(|dt| {
+                    use chrono::Local;
+                    let local: chrono::DateTime<Local> = dt.into();
+                    local.format("%-I:%M %p").to_string()
+                })
+                .unwrap_or_else(|| format!("{}s", reset_at - now_ts));
+
+            let reason = rl
+                .last_error
+                .clone()
+                .unwrap_or_else(|| "Rate limited".to_string());
+
+            return SyncHealth::Degraded {
+                reason,
+                guidance: format!(
+                    "Sync paused until {}. Will resume automatically.",
+                    reset_time
+                ),
+            };
+        }
+    }
+
+    // Check daemon status
+    if !daemon_running {
+        return SyncHealth::Unhealthy {
+            reason: "Daemon not running".to_string(),
+            guidance: "Start with: isq daemon start".to_string(),
+        };
+    }
+
+    // Check sync freshness
+    let Some(state) = sync_state else {
+        return SyncHealth::Unhealthy {
+            reason: "Never synced".to_string(),
+            guidance: "Run: isq sync".to_string(),
+        };
+    };
+
+    // Use last successful full sync time if available, fall back to issues_last_sync
+    let last_sync_str = state
+        .last_full_sync_at
+        .as_ref()
+        .or(state.issues_last_sync.as_ref());
+
+    let Some(last_sync_str) = last_sync_str else {
+        return SyncHealth::Unhealthy {
+            reason: "Never synced".to_string(),
+            guidance: "Run: isq sync".to_string(),
+        };
+    };
+
+    let Ok(last_sync) = DateTime::parse_from_rfc3339(last_sync_str) else {
+        return SyncHealth::Healthy; // Can't parse, assume OK
+    };
+
+    let minutes_since_sync = (now - last_sync.to_utc()).num_minutes();
+
+    if minutes_since_sync > VERY_STALE_SYNC_MINUTES {
+        return SyncHealth::Unhealthy {
+            reason: format!("Last sync was {}+ minutes ago", VERY_STALE_SYNC_MINUTES),
+            guidance: "Check daemon: isq daemon status".to_string(),
+        };
+    }
+
+    if minutes_since_sync > STALE_SYNC_MINUTES {
+        return SyncHealth::Degraded {
+            reason: format!("Last sync was {} minutes ago", minutes_since_sync),
+            guidance: "Data may be stale. Check: isq daemon status".to_string(),
+        };
+    }
+
+    SyncHealth::Healthy
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Surfaces sync health information in `isq status` to help users quickly
understand if sync is working and what to do when it's not.

Changes:
- Add SyncHealth enum (Healthy/Degraded/Unhealthy) with reasons and guidance
- Add calculate_sync_health() to evaluate sync state, rate limits, and daemon
- Update status command to display health with actionable guidance
- Show last successful sync time instead of just last attempt

Closes #25