### PR TITLE
Add forge-agnostic conflict resolution tests

### DIFF
--- a/src/daemon/queue.rs
+++ b/src/daemon/queue.rs
@@ -85,6 +85,26 @@ pub fn classify_error(err: &anyhow::Error) -> Option<ConflictKind> {
         return Some(ConflictKind::StateConflict);
     }
 
+    // Linear-specific mutation failures (GraphQL returned success: false)
+    // These are permanent failures - the API rejected the operation
+    if err_str.contains("failed to create comment")
+        || err_str.contains("failed to close issue")
+        || err_str.contains("failed to reopen issue")
+        || err_str.contains("failed to add label")
+        || err_str.contains("failed to remove label")
+        || err_str.contains("failed to assign issue")
+        || err_str.contains("failed to transition issue")
+        || err_str.contains("failed to create project")
+        || err_str.contains("failed to complete project")
+    {
+        return Some(ConflictKind::StateConflict);
+    }
+
+    // Linear workflow state not configured (team misconfiguration)
+    if err_str.contains("no workflow state") {
+        return Some(ConflictKind::ValidationError);
+    }
+
     // None = transient error, keep in queue for retry
     None
 }

--- a/src/daemon/tests.rs
+++ b/src/daemon/tests.rs
@@ -310,3 +310,38 @@ fn test_scenario_state_divergence_reopen_close_race() {
         Some(ConflictKind::StateConflict)
     );
 }
+
+/// Test: Linear mutation failures are classified as StateConflict
+/// These occur when GraphQL returns success: false
+#[test]
+fn test_classify_error_linear_mutation_failures() {
+    let cases = [
+        "Failed to create comment",
+        "Failed to close issue",
+        "Failed to reopen issue",
+        "Failed to add label",
+        "Failed to remove label",
+        "Failed to assign issue",
+        "Failed to transition issue",
+    ];
+
+    for msg in cases {
+        let err = anyhow::anyhow!("{}", msg);
+        assert_eq!(
+            classify_error(&err),
+            Some(ConflictKind::StateConflict),
+            "Linear mutation failure '{}' should be StateConflict",
+            msg
+        );
+    }
+}
+
+/// Test: Linear workflow state not found is classified as ValidationError
+#[test]
+fn test_classify_error_linear_no_workflow_state() {
+    let err = anyhow::anyhow!("No workflow state of type 'completed' found");
+    assert_eq!(classify_error(&err), Some(ConflictKind::ValidationError));
+
+    let err2 = anyhow::anyhow!("No workflow state matching 'Done' found");
+    assert_eq!(classify_error(&err2), Some(ConflictKind::ValidationError));
+}


### PR DESCRIPTION
Implements issue #4: Add tests for conflict resolution.

Changes:
- Add ConflictKind enum (NotFound, StateConflict, ValidationError)
- Add classify_error() with semantic pattern matching that works across
  GitHub (REST), Linear (GraphQL), and JIRA (REST)
- Refactor process_pending_ops() to use classify_error() instead of
  simple string matching for "404", "422", "409"
- Add 14 tests covering:
  - GitHub/JIRA/Linear error format detection
  - Semantic patterns ("not found", "already closed", etc.)
  - Network errors correctly NOT classified as conflicts
  - Server-wins conflict scenario (comment on closed issue)
  - Partial success scenario (deleted label)
  - State divergence scenario (reopen vs close race)

The new conflict detection is forge-agnostic, matching both HTTP status
codes and semantic error messages from GraphQL responses.