### PR TITLE
fix: accept bare issue numbers in isq start for Linear/JIRA

### DIFF
--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -31,6 +31,42 @@ pub fn is_offline_error(err: &anyhow::Error) -> bool {
         || err_str.contains("could not resolve")
 }
 
+/// Normalize an issue ID to the format stored in the database.
+///
+/// For forges that use prefixed IDs (Linear, JIRA), this ensures the prefix is present.
+/// - Linear: "413" -> "WRK-413" (prefix from forge_repo first component)
+/// - JIRA: "123" -> "DEV-123" (prefix from forge_repo last component)
+/// - GitHub: "123" -> "123" (no prefix needed)
+///
+/// If the ID already has a prefix, it's returned as-is (uppercased for consistency).
+pub fn normalize_issue_id(id: &str, forge_type: &str, forge_repo: &str) -> String {
+    // If already has a prefix, return as-is (uppercase the prefix for consistency)
+    if id.contains('-') {
+        let parts: Vec<&str> = id.splitn(2, '-').collect();
+        if parts.len() == 2 {
+            return format!("{}-{}", parts[0].to_uppercase(), parts[1]);
+        }
+    }
+
+    // Add prefix based on forge type
+    match forge_type {
+        "linear" => {
+            // forge_repo is "TEAM_KEY/workspace_uuid", prefix is the team key
+            let prefix = forge_repo.split('/').next().unwrap_or("");
+            format!("{}-{}", prefix, id)
+        }
+        "jira" => {
+            // forge_repo is "site/PROJECT_KEY", prefix is the project key
+            let prefix = forge_repo.split('/').next_back().unwrap_or("");
+            format!("{}-{}", prefix, id)
+        }
+        _ => {
+            // GitHub and others: no prefix needed
+            id.to_string()
+        }
+    }
+}
+
 /// Ensure the system service is installed and running
 pub fn ensure_service_running() -> Result<()> {
     let status = service::status()?;
@@ -100,4 +136,62 @@ pub fn validate_jira_issue_prefix(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_normalize_issue_id_linear_number_only() {
+        assert_eq!(
+            normalize_issue_id("413", "linear", "WRK/5328bff7-5748-4e00-a582-79c23d647aca"),
+            "WRK-413"
+        );
+    }
+
+    #[test]
+    fn test_normalize_issue_id_linear_with_prefix() {
+        assert_eq!(
+            normalize_issue_id(
+                "WRK-413",
+                "linear",
+                "WRK/5328bff7-5748-4e00-a582-79c23d647aca"
+            ),
+            "WRK-413"
+        );
+    }
+
+    #[test]
+    fn test_normalize_issue_id_linear_lowercase_prefix() {
+        assert_eq!(
+            normalize_issue_id(
+                "wrk-413",
+                "linear",
+                "WRK/5328bff7-5748-4e00-a582-79c23d647aca"
+            ),
+            "WRK-413"
+        );
+    }
+
+    #[test]
+    fn test_normalize_issue_id_jira_number_only() {
+        assert_eq!(
+            normalize_issue_id("123", "jira", "site.atlassian.net/DEV"),
+            "DEV-123"
+        );
+    }
+
+    #[test]
+    fn test_normalize_issue_id_jira_with_prefix() {
+        assert_eq!(
+            normalize_issue_id("DEV-123", "jira", "site.atlassian.net/DEV"),
+            "DEV-123"
+        );
+    }
+
+    #[test]
+    fn test_normalize_issue_id_github_unchanged() {
+        assert_eq!(normalize_issue_id("123", "github", "owner/repo"), "123");
+    }
 }

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -10,7 +10,7 @@ use crate::display;
 use crate::forges::{get_forge_for_repo, not_linked_error};
 use crate::repo;
 
-use super::utils::is_offline_error;
+use super::utils::{is_offline_error, normalize_issue_id};
 
 pub fn cmd_current(quiet: bool) -> Result<()> {
     let git_dir = repo::detect_git_dir()?;
@@ -81,14 +81,17 @@ pub async fn cmd_start(id: String) -> Result<()> {
     // Get linked forge repo
     let link = db::get_repo_link(&conn, &repo_path)?.ok_or_else(not_linked_error)?;
 
+    // Normalize the issue ID to match the stored format (e.g., "413" -> "WRK-413" for Linear)
+    let issue_id = normalize_issue_id(&id, &link.forge_type, &link.forge_repo);
+
     // Load issue from cache (fast!)
-    let issue_display = display::format_issue_id(&id);
-    let issue = db::load_issue(&conn, &link.forge_repo, &id)?.ok_or_else(|| {
+    let issue_display = display::format_issue_id(&issue_id);
+    let issue = db::load_issue(&conn, &link.forge_repo, &issue_id)?.ok_or_else(|| {
         anyhow::anyhow!("Issue {} not found. Run `isq sync` first.", issue_display)
     })?;
 
-    // Create branch name: {id}-{slugified-title}
-    let branch = format!("{}-{}", id, repo::slugify(&issue.title));
+    // Create branch name: {issue_id}-{slugified-title}
+    let branch = format!("{}-{}", issue_id, repo::slugify(&issue.title));
 
     // Load and validate config BEFORE creating worktree (fail fast)
     let repo_config = config::load_repo_config(std::path::Path::new(&repo_path))?;
@@ -119,9 +122,9 @@ pub async fn cmd_start(id: String) -> Result<()> {
     let user_id = link.user_id.clone();
 
     // Run DB association, setup script, and forge actions concurrently
-    let id_for_db = id.clone();
-    let id_for_setup = id.clone();
-    let id_for_forge = id.clone();
+    let id_for_db = issue_id.clone();
+    let id_for_setup = issue_id.clone();
+    let id_for_forge = issue_id.clone();
     let db_future = async { db::set_worktree_issue(&conn, &git_dir_str, &forge_repo, &id_for_db) };
 
     let setup_future = async {

--- a/src/forges/github/comments.rs
+++ b/src/forges/github/comments.rs
@@ -75,7 +75,12 @@ impl GitHubClient {
                 }
             }
             completed += 1;
-            trace!(completed, total_pages, comments = all_comments.len(), "Comments fetch progress");
+            trace!(
+                completed,
+                total_pages,
+                comments = all_comments.len(),
+                "Comments fetch progress"
+            );
         }
 
         // Warn if we got partial results
@@ -196,7 +201,12 @@ impl GitHubClient {
             let body = response.text().await?;
 
             if is_rate_limited(status, &body) && attempt < MAX_RETRIES - 1 {
-                debug!(page = 1, attempt, delay_ms = delay.as_millis(), "Rate limited, retrying");
+                debug!(
+                    page = 1,
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    "Rate limited, retrying"
+                );
                 tokio::time::sleep(delay).await;
                 continue;
             }
@@ -276,7 +286,12 @@ impl GitHubClient {
             let body = response.text().await?;
 
             if is_rate_limited(status, &body) && attempt < MAX_RETRIES - 1 {
-                debug!(page, attempt, delay_ms = delay.as_millis(), "Rate limited, retrying");
+                debug!(
+                    page,
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    "Rate limited, retrying"
+                );
                 tokio::time::sleep(delay).await;
                 continue;
             }

--- a/src/forges/jira/comments.rs
+++ b/src/forges/jira/comments.rs
@@ -96,7 +96,11 @@ impl JiraClient {
             }
 
             page += 1;
-            trace!(page, total = all_comments.len(), "Fetched JIRA comments page");
+            trace!(
+                page,
+                total = all_comments.len(),
+                "Fetched JIRA comments page"
+            );
 
             match response.next_page_token {
                 Some(token) => next_page_token = Some(token),

--- a/src/forges/linear/comments.rs
+++ b/src/forges/linear/comments.rs
@@ -110,7 +110,11 @@ impl LinearClient {
                     }
 
                     page += 1;
-                    trace!(page, total = all_comments.len(), "Fetched Linear comments page");
+                    trace!(
+                        page,
+                        total = all_comments.len(),
+                        "Fetched Linear comments page"
+                    );
 
                     let page_info = response.comments.page_info.unwrap_or(PageInfo {
                         has_next_page: false,


### PR DESCRIPTION
## Summary
- `isq start 413` was failing with "Issue not found" for Linear repos because the database stores `WRK-413` but the command passed `413` directly to the lookup
- Added `normalize_issue_id()` to prepend the appropriate prefix (Linear team key or JIRA project key) before querying

## Test plan
- [x] `cargo test normalize_issue_id` - 6 unit tests pass
- [x] `cargo test` - all 153 tests pass
- [ ] Manual test: `isq start 413` in a Linear-linked repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)