### PR TITLE
docs: add agent skill install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ isq uninstall --keep-config  # Preserve your views and settings
 isq uninstall --dry-run      # Preview what would be removed
 ```
 
+## Agent Skill
+
+Teach your AI coding agent to use isq for issue management:
+
+```bash
+npx add-skill camwest/isq
+```
+
+Works with Claude Code, Cursor, Codex, Windsurf, and [other agents](https://github.com/vercel-labs/add-skill#available-agents).
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds an "Agent Skill" section to README showing how to install the isq skill for AI coding agents
- Links to supported agents (Claude Code, Cursor, Codex, Windsurf, etc.)

## Test plan
- [x] Verify the `npx add-skill camwest/isq` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)